### PR TITLE
insert

### DIFF
--- a/src/eimerdb/instance.py
+++ b/src/eimerdb/instance.py
@@ -646,7 +646,7 @@ class EimerDBInstance:
             merged = self.query(
                 f"SELECT * FROM {table_name}", partition_select=None, unedited=False
             )
-            self.main_table_insert(table_name, merged, raw=False)
+            self.main_table_insert(table_name, merged)
             partitions = self.tables[table_name]["partition_columns"]
             partition_levels = "**/" * len(partitions) + "*"
             fs = FileClient.get_gcs_file_system()


### PR DESCRIPTION
made changes to the main_table_insert-method.
- renamed method to "insert"
- It is now possible to insert multiple times into a table.
- the raw-table now includes username of the one who inserted into the table, datetime and operation = insert.