### PR TITLE
Method get_inserts and combine_inserts

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4475,4 +4475,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "8f58a3fcf32c530a20b7066e30e82e50fa6585d7cd5683fe44ae4ad481bfef4e"
+content-hash = "9766879dbfcd5bb6c89977f7a44becfa5dd3a223a8de2035c0e23b7e51febe1b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2585,6 +2585,20 @@ test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
 
 [[package]]
+name = "parameterized"
+version = "0.9.0"
+description = "Parameterized testing with any Python test framework"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "parameterized-0.9.0-py2.py3-none-any.whl", hash = "sha256:4e0758e3d41bea3bbd05ec14fc2c24736723f243b28d702081aef438c9372b1b"},
+    {file = "parameterized-0.9.0.tar.gz", hash = "sha256:7fc905272cefa4f364c1a3429cbbe9c0f98b793988efb5bf90aac80f08db09b1"},
+]
+
+[package.extras]
+dev = ["jinja2"]
+
+[[package]]
 name = "parso"
 version = "0.8.3"
 description = "A Python Parser"
@@ -3282,6 +3296,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4460,4 +4475,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "19bbd8d157ba31ad61ba59d77e15b1293c0b959c705bdc0fb02288423506e630"
+content-hash = "8f58a3fcf32c530a20b7066e30e82e50fa6585d7cd5683fe44ae4ad481bfef4e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4475,4 +4475,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "b86637d8d9086a14792c121acc400753d487a3e7f97efca384964c3ce41f4b1b"
+content-hash = "e1bbf7287f1be548fb851d4524be50c54bb9588a7a42f01e19bc94989ee9bdeb"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4475,4 +4475,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "e1bbf7287f1be548fb851d4524be50c54bb9588a7a42f01e19bc94989ee9bdeb"
+content-hash = "9766879dbfcd5bb6c89977f7a44becfa5dd3a223a8de2035c0e23b7e51febe1b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -240,13 +240,13 @@ dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
 [[package]]
 name = "bandit"
-version = "1.7.7"
+version = "1.7.8"
 description = "Security oriented static analyser for python code."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "bandit-1.7.7-py3-none-any.whl", hash = "sha256:17e60786a7ea3c9ec84569fd5aee09936d116cb0cb43151023258340dbffb7ed"},
-    {file = "bandit-1.7.7.tar.gz", hash = "sha256:527906bec6088cb499aae31bc962864b4e77569e9d529ee51df3a93b4b8ab28a"},
+    {file = "bandit-1.7.8-py3-none-any.whl", hash = "sha256:509f7af645bc0cd8fd4587abc1a038fc795636671ee8204d502b933aee44f381"},
+    {file = "bandit-1.7.8.tar.gz", hash = "sha256:36de50f720856ab24a24dbaa5fee2c66050ed97c1477e0a1159deab1775eab6b"},
 ]
 
 [package.dependencies]
@@ -257,6 +257,7 @@ stevedore = ">=1.20.0"
 
 [package.extras]
 baseline = ["GitPython (>=3.1.30)"]
+sarif = ["jschema-to-python (>=1.2.3)", "sarif-om (>=1.0.4)"]
 test = ["beautifulsoup4 (>=4.8.0)", "coverage (>=4.5.4)", "fixtures (>=3.0.0)", "flake8 (>=4.0.0)", "pylint (==1.9.4)", "stestr (>=2.5.0)", "testscenarios (>=0.5.0)", "testtools (>=2.3.0)"]
 toml = ["tomli (>=1.1.0)"]
 yaml = ["PyYAML"]
@@ -571,13 +572,13 @@ files = [
 
 [[package]]
 name = "comm"
-version = "0.2.1"
+version = "0.2.2"
 description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "comm-0.2.1-py3-none-any.whl", hash = "sha256:87928485c0dfc0e7976fd89fc1e187023cf587e7c353e4a9b417555b44adf021"},
-    {file = "comm-0.2.1.tar.gz", hash = "sha256:0bc91edae1344d39d3661dcbc36937181fdaddb304790458f8b044dbc064b89a"},
+    {file = "comm-0.2.2-py3-none-any.whl", hash = "sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3"},
+    {file = "comm-0.2.2.tar.gz", hash = "sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e"},
 ]
 
 [package.dependencies]
@@ -709,13 +710,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dapla-toolbelt"
-version = "2.0.8"
+version = "2.0.10"
 description = "Dapla Toolbelt"
 optional = false
 python-versions = ">=3.10,<4.0"
 files = [
-    {file = "dapla_toolbelt-2.0.8-py3-none-any.whl", hash = "sha256:1fe2d12fcd1bf0bc9766743e97cab5d3870b554c07a6c942296ef7d6bd513167"},
-    {file = "dapla_toolbelt-2.0.8.tar.gz", hash = "sha256:3043161cc819057341d7a65ec36c9beecd8ab79e087c0e62371ef04d82f798a2"},
+    {file = "dapla_toolbelt-2.0.10-py3-none-any.whl", hash = "sha256:70fc0edbc841bce35eef8651564830a4dc0d8f999ca2942b1fe7b963a856532f"},
+    {file = "dapla_toolbelt-2.0.10.tar.gz", hash = "sha256:57f2fcaf7c84f95311d34b7a12eea740cc69edf321a66f197ddc5d826d971344"},
 ]
 
 [package.dependencies]
@@ -1211,13 +1212,13 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-auth"
-version = "2.28.1"
+version = "2.28.2"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-auth-2.28.1.tar.gz", hash = "sha256:34fc3046c257cedcf1622fc4b31fc2be7923d9b4d44973d481125ecc50d83885"},
-    {file = "google_auth-2.28.1-py2.py3-none-any.whl", hash = "sha256:25141e2d7a14bfcba945f5e9827f98092716e99482562f15306e5b026e21aa72"},
+    {file = "google-auth-2.28.2.tar.gz", hash = "sha256:80b8b4969aa9ed5938c7828308f20f035bc79f9d8fb8120bf9dc8db20b41ba30"},
+    {file = "google_auth-2.28.2-py2.py3-none-any.whl", hash = "sha256:9fd67bbcd40f16d9d42f950228e9cf02a2ded4ae49198b27432d0cded5a74c38"},
 ]
 
 [package.dependencies]
@@ -1416,13 +1417,13 @@ requests = ["requests (>=2.18.0,<3.0.0dev)"]
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.62.0"
+version = "1.63.0"
 description = "Common protobufs used in Google APIs"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "googleapis-common-protos-1.62.0.tar.gz", hash = "sha256:83f0ece9f94e5672cced82f592d2a5edf527a96ed1794f0bab36d5735c996277"},
-    {file = "googleapis_common_protos-1.62.0-py2.py3-none-any.whl", hash = "sha256:4750113612205514f9f6aa4cb00d523a94f3e8c06c5ad2fee466387dc4875f07"},
+    {file = "googleapis-common-protos-1.63.0.tar.gz", hash = "sha256:17ad01b11d5f1d0171c06d3ba5c04c54474e883b66b949722b4938ee2694ef4e"},
+    {file = "googleapis_common_protos-1.63.0-py2.py3-none-any.whl", hash = "sha256:ae45f75702f7c08b541f750854a678bd8f534a1a6bace6afe975f1d0a82d6632"},
 ]
 
 [package.dependencies]
@@ -1521,84 +1522,84 @@ protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.1 || >4.21.1,<4
 
 [[package]]
 name = "grpcio"
-version = "1.62.0"
+version = "1.62.1"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "grpcio-1.62.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:136ffd79791b1eddda8d827b607a6285474ff8a1a5735c4947b58c481e5e4271"},
-    {file = "grpcio-1.62.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:d6a56ba703be6b6267bf19423d888600c3f574ac7c2cc5e6220af90662a4d6b0"},
-    {file = "grpcio-1.62.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:4cd356211579043fce9f52acc861e519316fff93980a212c8109cca8f47366b6"},
-    {file = "grpcio-1.62.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e803e9b58d8f9b4ff0ea991611a8d51b31c68d2e24572cd1fe85e99e8cc1b4f8"},
-    {file = "grpcio-1.62.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4c04fe33039b35b97c02d2901a164bbbb2f21fb9c4e2a45a959f0b044c3512c"},
-    {file = "grpcio-1.62.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:95370c71b8c9062f9ea033a0867c4c73d6f0ff35113ebd2618171ec1f1e903e0"},
-    {file = "grpcio-1.62.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c912688acc05e4ff012c8891803659d6a8a8b5106f0f66e0aed3fb7e77898fa6"},
-    {file = "grpcio-1.62.0-cp310-cp310-win32.whl", hash = "sha256:821a44bd63d0f04e33cf4ddf33c14cae176346486b0df08b41a6132b976de5fc"},
-    {file = "grpcio-1.62.0-cp310-cp310-win_amd64.whl", hash = "sha256:81531632f93fece32b2762247c4c169021177e58e725494f9a746ca62c83acaa"},
-    {file = "grpcio-1.62.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:3fa15850a6aba230eed06b236287c50d65a98f05054a0f01ccedf8e1cc89d57f"},
-    {file = "grpcio-1.62.0-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:36df33080cd7897623feff57831eb83c98b84640b016ce443305977fac7566fb"},
-    {file = "grpcio-1.62.0-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:7a195531828b46ea9c4623c47e1dc45650fc7206f8a71825898dd4c9004b0928"},
-    {file = "grpcio-1.62.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ab140a3542bbcea37162bdfc12ce0d47a3cda3f2d91b752a124cc9fe6776a9e2"},
-    {file = "grpcio-1.62.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f9d6c3223914abb51ac564dc9c3782d23ca445d2864321b9059d62d47144021"},
-    {file = "grpcio-1.62.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:fbe0c20ce9a1cff75cfb828b21f08d0a1ca527b67f2443174af6626798a754a4"},
-    {file = "grpcio-1.62.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:38f69de9c28c1e7a8fd24e4af4264726637b72f27c2099eaea6e513e7142b47e"},
-    {file = "grpcio-1.62.0-cp311-cp311-win32.whl", hash = "sha256:ce1aafdf8d3f58cb67664f42a617af0e34555fe955450d42c19e4a6ad41c84bd"},
-    {file = "grpcio-1.62.0-cp311-cp311-win_amd64.whl", hash = "sha256:eef1d16ac26c5325e7d39f5452ea98d6988c700c427c52cbc7ce3201e6d93334"},
-    {file = "grpcio-1.62.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:8aab8f90b2a41208c0a071ec39a6e5dbba16fd827455aaa070fec241624ccef8"},
-    {file = "grpcio-1.62.0-cp312-cp312-macosx_10_10_universal2.whl", hash = "sha256:62aa1659d8b6aad7329ede5d5b077e3d71bf488d85795db517118c390358d5f6"},
-    {file = "grpcio-1.62.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:0d7ae7fc7dbbf2d78d6323641ded767d9ec6d121aaf931ec4a5c50797b886532"},
-    {file = "grpcio-1.62.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f359d635ee9428f0294bea062bb60c478a8ddc44b0b6f8e1f42997e5dc12e2ee"},
-    {file = "grpcio-1.62.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d48e5b1f8f4204889f1acf30bb57c30378e17c8d20df5acbe8029e985f735c"},
-    {file = "grpcio-1.62.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:662d3df5314ecde3184cf87ddd2c3a66095b3acbb2d57a8cada571747af03873"},
-    {file = "grpcio-1.62.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:92cdb616be44c8ac23a57cce0243af0137a10aa82234f23cd46e69e115071388"},
-    {file = "grpcio-1.62.0-cp312-cp312-win32.whl", hash = "sha256:0b9179478b09ee22f4a36b40ca87ad43376acdccc816ce7c2193a9061bf35701"},
-    {file = "grpcio-1.62.0-cp312-cp312-win_amd64.whl", hash = "sha256:614c3ed234208e76991992342bab725f379cc81c7dd5035ee1de2f7e3f7a9842"},
-    {file = "grpcio-1.62.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:7e1f51e2a460b7394670fdb615e26d31d3260015154ea4f1501a45047abe06c9"},
-    {file = "grpcio-1.62.0-cp37-cp37m-macosx_10_10_universal2.whl", hash = "sha256:bcff647e7fe25495e7719f779cc219bbb90b9e79fbd1ce5bda6aae2567f469f2"},
-    {file = "grpcio-1.62.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:56ca7ba0b51ed0de1646f1735154143dcbdf9ec2dbe8cc6645def299bb527ca1"},
-    {file = "grpcio-1.62.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e84bfb2a734e4a234b116be208d6f0214e68dcf7804306f97962f93c22a1839"},
-    {file = "grpcio-1.62.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c1488b31a521fbba50ae86423f5306668d6f3a46d124f7819c603979fc538c4"},
-    {file = "grpcio-1.62.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:98d8f4eb91f1ce0735bf0b67c3b2a4fea68b52b2fd13dc4318583181f9219b4b"},
-    {file = "grpcio-1.62.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:b3d3d755cfa331d6090e13aac276d4a3fb828bf935449dc16c3d554bf366136b"},
-    {file = "grpcio-1.62.0-cp37-cp37m-win_amd64.whl", hash = "sha256:a33f2bfd8a58a02aab93f94f6c61279be0f48f99fcca20ebaee67576cd57307b"},
-    {file = "grpcio-1.62.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:5e709f7c8028ce0443bddc290fb9c967c1e0e9159ef7a030e8c21cac1feabd35"},
-    {file = "grpcio-1.62.0-cp38-cp38-macosx_10_10_universal2.whl", hash = "sha256:2f3d9a4d0abb57e5f49ed5039d3ed375826c2635751ab89dcc25932ff683bbb6"},
-    {file = "grpcio-1.62.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:62ccb92f594d3d9fcd00064b149a0187c246b11e46ff1b7935191f169227f04c"},
-    {file = "grpcio-1.62.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:921148f57c2e4b076af59a815467d399b7447f6e0ee10ef6d2601eb1e9c7f402"},
-    {file = "grpcio-1.62.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f897b16190b46bc4d4aaf0a32a4b819d559a37a756d7c6b571e9562c360eed72"},
-    {file = "grpcio-1.62.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1bc8449084fe395575ed24809752e1dc4592bb70900a03ca42bf236ed5bf008f"},
-    {file = "grpcio-1.62.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:81d444e5e182be4c7856cd33a610154fe9ea1726bd071d07e7ba13fafd202e38"},
-    {file = "grpcio-1.62.0-cp38-cp38-win32.whl", hash = "sha256:88f41f33da3840b4a9bbec68079096d4caf629e2c6ed3a72112159d570d98ebe"},
-    {file = "grpcio-1.62.0-cp38-cp38-win_amd64.whl", hash = "sha256:fc2836cb829895ee190813446dce63df67e6ed7b9bf76060262c55fcd097d270"},
-    {file = "grpcio-1.62.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:fcc98cff4084467839d0a20d16abc2a76005f3d1b38062464d088c07f500d170"},
-    {file = "grpcio-1.62.0-cp39-cp39-macosx_10_10_universal2.whl", hash = "sha256:0d3dee701e48ee76b7d6fbbba18ba8bc142e5b231ef7d3d97065204702224e0e"},
-    {file = "grpcio-1.62.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:b7a6be562dd18e5d5bec146ae9537f20ae1253beb971c0164f1e8a2f5a27e829"},
-    {file = "grpcio-1.62.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:29cb592c4ce64a023712875368bcae13938c7f03e99f080407e20ffe0a9aa33b"},
-    {file = "grpcio-1.62.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1eda79574aec8ec4d00768dcb07daba60ed08ef32583b62b90bbf274b3c279f7"},
-    {file = "grpcio-1.62.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7eea57444a354ee217fda23f4b479a4cdfea35fb918ca0d8a0e73c271e52c09c"},
-    {file = "grpcio-1.62.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0e97f37a3b7c89f9125b92d22e9c8323f4e76e7993ba7049b9f4ccbe8bae958a"},
-    {file = "grpcio-1.62.0-cp39-cp39-win32.whl", hash = "sha256:39cd45bd82a2e510e591ca2ddbe22352e8413378852ae814549c162cf3992a93"},
-    {file = "grpcio-1.62.0-cp39-cp39-win_amd64.whl", hash = "sha256:b71c65427bf0ec6a8b48c68c17356cb9fbfc96b1130d20a07cb462f4e4dcdcd5"},
-    {file = "grpcio-1.62.0.tar.gz", hash = "sha256:748496af9238ac78dcd98cce65421f1adce28c3979393e3609683fcd7f3880d7"},
+    {file = "grpcio-1.62.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:179bee6f5ed7b5f618844f760b6acf7e910988de77a4f75b95bbfaa8106f3c1e"},
+    {file = "grpcio-1.62.1-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:48611e4fa010e823ba2de8fd3f77c1322dd60cb0d180dc6630a7e157b205f7ea"},
+    {file = "grpcio-1.62.1-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:b2a0e71b0a2158aa4bce48be9f8f9eb45cbd17c78c7443616d00abbe2a509f6d"},
+    {file = "grpcio-1.62.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fbe80577c7880911d3ad65e5ecc997416c98f354efeba2f8d0f9112a67ed65a5"},
+    {file = "grpcio-1.62.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58f6c693d446964e3292425e1d16e21a97a48ba9172f2d0df9d7b640acb99243"},
+    {file = "grpcio-1.62.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:77c339403db5a20ef4fed02e4d1a9a3d9866bf9c0afc77a42234677313ea22f3"},
+    {file = "grpcio-1.62.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b5a4ea906db7dec694098435d84bf2854fe158eb3cd51e1107e571246d4d1d70"},
+    {file = "grpcio-1.62.1-cp310-cp310-win32.whl", hash = "sha256:4187201a53f8561c015bc745b81a1b2d278967b8de35f3399b84b0695e281d5f"},
+    {file = "grpcio-1.62.1-cp310-cp310-win_amd64.whl", hash = "sha256:844d1f3fb11bd1ed362d3fdc495d0770cfab75761836193af166fee113421d66"},
+    {file = "grpcio-1.62.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:833379943d1728a005e44103f17ecd73d058d37d95783eb8f0b28ddc1f54d7b2"},
+    {file = "grpcio-1.62.1-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:c7fcc6a32e7b7b58f5a7d27530669337a5d587d4066060bcb9dee7a8c833dfb7"},
+    {file = "grpcio-1.62.1-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:fa7d28eb4d50b7cbe75bb8b45ed0da9a1dc5b219a0af59449676a29c2eed9698"},
+    {file = "grpcio-1.62.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48f7135c3de2f298b833be8b4ae20cafe37091634e91f61f5a7eb3d61ec6f660"},
+    {file = "grpcio-1.62.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71f11fd63365ade276c9d4a7b7df5c136f9030e3457107e1791b3737a9b9ed6a"},
+    {file = "grpcio-1.62.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4b49fd8fe9f9ac23b78437da94c54aa7e9996fbb220bac024a67469ce5d0825f"},
+    {file = "grpcio-1.62.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:482ae2ae78679ba9ed5752099b32e5fe580443b4f798e1b71df412abf43375db"},
+    {file = "grpcio-1.62.1-cp311-cp311-win32.whl", hash = "sha256:1faa02530b6c7426404372515fe5ddf66e199c2ee613f88f025c6f3bd816450c"},
+    {file = "grpcio-1.62.1-cp311-cp311-win_amd64.whl", hash = "sha256:5bd90b8c395f39bc82a5fb32a0173e220e3f401ff697840f4003e15b96d1befc"},
+    {file = "grpcio-1.62.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:b134d5d71b4e0837fff574c00e49176051a1c532d26c052a1e43231f252d813b"},
+    {file = "grpcio-1.62.1-cp312-cp312-macosx_10_10_universal2.whl", hash = "sha256:d1f6c96573dc09d50dbcbd91dbf71d5cf97640c9427c32584010fbbd4c0e0037"},
+    {file = "grpcio-1.62.1-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:359f821d4578f80f41909b9ee9b76fb249a21035a061a327f91c953493782c31"},
+    {file = "grpcio-1.62.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a485f0c2010c696be269184bdb5ae72781344cb4e60db976c59d84dd6354fac9"},
+    {file = "grpcio-1.62.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b50b09b4dc01767163d67e1532f948264167cd27f49e9377e3556c3cba1268e1"},
+    {file = "grpcio-1.62.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3227c667dccbe38f2c4d943238b887bac588d97c104815aecc62d2fd976e014b"},
+    {file = "grpcio-1.62.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3952b581eb121324853ce2b191dae08badb75cd493cb4e0243368aa9e61cfd41"},
+    {file = "grpcio-1.62.1-cp312-cp312-win32.whl", hash = "sha256:83a17b303425104d6329c10eb34bba186ffa67161e63fa6cdae7776ff76df73f"},
+    {file = "grpcio-1.62.1-cp312-cp312-win_amd64.whl", hash = "sha256:6696ffe440333a19d8d128e88d440f91fb92c75a80ce4b44d55800e656a3ef1d"},
+    {file = "grpcio-1.62.1-cp37-cp37m-linux_armv7l.whl", hash = "sha256:e3393b0823f938253370ebef033c9fd23d27f3eae8eb9a8f6264900c7ea3fb5a"},
+    {file = "grpcio-1.62.1-cp37-cp37m-macosx_10_10_universal2.whl", hash = "sha256:83e7ccb85a74beaeae2634f10eb858a0ed1a63081172649ff4261f929bacfd22"},
+    {file = "grpcio-1.62.1-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:882020c87999d54667a284c7ddf065b359bd00251fcd70279ac486776dbf84ec"},
+    {file = "grpcio-1.62.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a10383035e864f386fe096fed5c47d27a2bf7173c56a6e26cffaaa5a361addb1"},
+    {file = "grpcio-1.62.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:960edebedc6b9ada1ef58e1c71156f28689978188cd8cff3b646b57288a927d9"},
+    {file = "grpcio-1.62.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:23e2e04b83f347d0aadde0c9b616f4726c3d76db04b438fd3904b289a725267f"},
+    {file = "grpcio-1.62.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:978121758711916d34fe57c1f75b79cdfc73952f1481bb9583399331682d36f7"},
+    {file = "grpcio-1.62.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9084086190cc6d628f282e5615f987288b95457292e969b9205e45b442276407"},
+    {file = "grpcio-1.62.1-cp38-cp38-linux_armv7l.whl", hash = "sha256:22bccdd7b23c420a27fd28540fb5dcbc97dc6be105f7698cb0e7d7a420d0e362"},
+    {file = "grpcio-1.62.1-cp38-cp38-macosx_10_10_universal2.whl", hash = "sha256:8999bf1b57172dbc7c3e4bb3c732658e918f5c333b2942243f10d0d653953ba9"},
+    {file = "grpcio-1.62.1-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:d9e52558b8b8c2f4ac05ac86344a7417ccdd2b460a59616de49eb6933b07a0bd"},
+    {file = "grpcio-1.62.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1714e7bc935780bc3de1b3fcbc7674209adf5208ff825799d579ffd6cd0bd505"},
+    {file = "grpcio-1.62.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8842ccbd8c0e253c1f189088228f9b433f7a93b7196b9e5b6f87dba393f5d5d"},
+    {file = "grpcio-1.62.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1f1e7b36bdff50103af95a80923bf1853f6823dd62f2d2a2524b66ed74103e49"},
+    {file = "grpcio-1.62.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bba97b8e8883a8038606480d6b6772289f4c907f6ba780fa1f7b7da7dfd76f06"},
+    {file = "grpcio-1.62.1-cp38-cp38-win32.whl", hash = "sha256:a7f615270fe534548112a74e790cd9d4f5509d744dd718cd442bf016626c22e4"},
+    {file = "grpcio-1.62.1-cp38-cp38-win_amd64.whl", hash = "sha256:e6c8c8693df718c5ecbc7babb12c69a4e3677fd11de8886f05ab22d4e6b1c43b"},
+    {file = "grpcio-1.62.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:73db2dc1b201d20ab7083e7041946910bb991e7e9761a0394bbc3c2632326483"},
+    {file = "grpcio-1.62.1-cp39-cp39-macosx_10_10_universal2.whl", hash = "sha256:407b26b7f7bbd4f4751dbc9767a1f0716f9fe72d3d7e96bb3ccfc4aace07c8de"},
+    {file = "grpcio-1.62.1-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:f8de7c8cef9261a2d0a62edf2ccea3d741a523c6b8a6477a340a1f2e417658de"},
+    {file = "grpcio-1.62.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bd5c8a1af40ec305d001c60236308a67e25419003e9bb3ebfab5695a8d0b369"},
+    {file = "grpcio-1.62.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be0477cb31da67846a33b1a75c611f88bfbcd427fe17701b6317aefceee1b96f"},
+    {file = "grpcio-1.62.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:60dcd824df166ba266ee0cfaf35a31406cd16ef602b49f5d4dfb21f014b0dedd"},
+    {file = "grpcio-1.62.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:973c49086cabab773525f6077f95e5a993bfc03ba8fc32e32f2c279497780585"},
+    {file = "grpcio-1.62.1-cp39-cp39-win32.whl", hash = "sha256:12859468e8918d3bd243d213cd6fd6ab07208195dc140763c00dfe901ce1e1b4"},
+    {file = "grpcio-1.62.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7209117bbeebdfa5d898205cc55153a51285757902dd73c47de498ad4d11332"},
+    {file = "grpcio-1.62.1.tar.gz", hash = "sha256:6c455e008fa86d9e9a9d85bb76da4277c0d7d9668a3bfa70dbe86e9f3c759947"},
 ]
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.62.0)"]
+protobuf = ["grpcio-tools (>=1.62.1)"]
 
 [[package]]
 name = "grpcio-status"
-version = "1.62.0"
+version = "1.62.1"
 description = "Status proto mapping for gRPC"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "grpcio-status-1.62.0.tar.gz", hash = "sha256:0d693e9c09880daeaac060d0c3dba1ae470a43c99e5d20dfeafd62cf7e08a85d"},
-    {file = "grpcio_status-1.62.0-py3-none-any.whl", hash = "sha256:3baac03fcd737310e67758c4082a188107f771d32855bce203331cd4c9aa687a"},
+    {file = "grpcio-status-1.62.1.tar.gz", hash = "sha256:3431c8abbab0054912c41df5c72f03ddf3b7a67be8a287bb3c18a3456f96ff77"},
+    {file = "grpcio_status-1.62.1-py3-none-any.whl", hash = "sha256:af0c3ab85da31669f21749e8d53d669c061ebc6ce5637be49a46edcb7aa8ab17"},
 ]
 
 [package.dependencies]
 googleapis-common-protos = ">=1.5.5"
-grpcio = ">=1.62.0"
+grpcio = ">=1.62.1"
 protobuf = ">=4.21.6"
 
 [[package]]
@@ -1804,13 +1805,13 @@ referencing = ">=0.31.0"
 
 [[package]]
 name = "jupyter-client"
-version = "8.6.0"
+version = "8.6.1"
 description = "Jupyter protocol implementation and client libraries"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_client-8.6.0-py3-none-any.whl", hash = "sha256:909c474dbe62582ae62b758bca86d6518c85234bdee2d908c778db6d72f39d99"},
-    {file = "jupyter_client-8.6.0.tar.gz", hash = "sha256:0642244bb83b4764ae60d07e010e15f0e2d275ec4e918a8f7b80fbbef3ca60c7"},
+    {file = "jupyter_client-8.6.1-py3-none-any.whl", hash = "sha256:3b7bd22f058434e3b9a7ea4b1500ed47de2713872288c0d511d19926f99b459f"},
+    {file = "jupyter_client-8.6.1.tar.gz", hash = "sha256:e842515e2bab8e19186d89fdfea7abd15e39dd581f94e399f00e2af5a1652d3f"},
 ]
 
 [package.dependencies]
@@ -1826,13 +1827,13 @@ test = ["coverage", "ipykernel (>=6.14)", "mypy", "paramiko", "pre-commit", "pyt
 
 [[package]]
 name = "jupyter-core"
-version = "5.7.1"
+version = "5.7.2"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_core-5.7.1-py3-none-any.whl", hash = "sha256:c65c82126453a723a2804aa52409930434598fd9d35091d63dfb919d2b765bb7"},
-    {file = "jupyter_core-5.7.1.tar.gz", hash = "sha256:de61a9d7fc71240f688b2fb5ab659fbb56979458dc66a71decd098e03c79e218"},
+    {file = "jupyter_core-5.7.2-py3-none-any.whl", hash = "sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409"},
+    {file = "jupyter_core-5.7.2.tar.gz", hash = "sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9"},
 ]
 
 [package.dependencies]
@@ -1842,7 +1843,7 @@ traitlets = ">=5.3"
 
 [package.extras]
 docs = ["myst-parser", "pydata-sphinx-theme", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "traitlets"]
-test = ["ipykernel", "pre-commit", "pytest", "pytest-cov", "pytest-timeout"]
+test = ["ipykernel", "pre-commit", "pytest (<8)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyter-telemetry"
@@ -2287,38 +2288,38 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.8.0"
+version = "1.9.0"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:485a8942f671120f76afffff70f259e1cd0f0cfe08f81c05d8816d958d4577d3"},
-    {file = "mypy-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:df9824ac11deaf007443e7ed2a4a26bebff98d2bc43c6da21b2b64185da011c4"},
-    {file = "mypy-1.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2afecd6354bbfb6e0160f4e4ad9ba6e4e003b767dd80d85516e71f2e955ab50d"},
-    {file = "mypy-1.8.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8963b83d53ee733a6e4196954502b33567ad07dfd74851f32be18eb932fb1cb9"},
-    {file = "mypy-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:e46f44b54ebddbeedbd3d5b289a893219065ef805d95094d16a0af6630f5d410"},
-    {file = "mypy-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:855fe27b80375e5c5878492f0729540db47b186509c98dae341254c8f45f42ae"},
-    {file = "mypy-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4c886c6cce2d070bd7df4ec4a05a13ee20c0aa60cb587e8d1265b6c03cf91da3"},
-    {file = "mypy-1.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d19c413b3c07cbecf1f991e2221746b0d2a9410b59cb3f4fb9557f0365a1a817"},
-    {file = "mypy-1.8.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9261ed810972061388918c83c3f5cd46079d875026ba97380f3e3978a72f503d"},
-    {file = "mypy-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:51720c776d148bad2372ca21ca29256ed483aa9a4cdefefcef49006dff2a6835"},
-    {file = "mypy-1.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:52825b01f5c4c1c4eb0db253ec09c7aa17e1a7304d247c48b6f3599ef40db8bd"},
-    {file = "mypy-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5ac9a4eeb1ec0f1ccdc6f326bcdb464de5f80eb07fb38b5ddd7b0de6bc61e55"},
-    {file = "mypy-1.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afe3fe972c645b4632c563d3f3eff1cdca2fa058f730df2b93a35e3b0c538218"},
-    {file = "mypy-1.8.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:42c6680d256ab35637ef88891c6bd02514ccb7e1122133ac96055ff458f93fc3"},
-    {file = "mypy-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:720a5ca70e136b675af3af63db533c1c8c9181314d207568bbe79051f122669e"},
-    {file = "mypy-1.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:028cf9f2cae89e202d7b6593cd98db6759379f17a319b5faf4f9978d7084cdc6"},
-    {file = "mypy-1.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4e6d97288757e1ddba10dd9549ac27982e3e74a49d8d0179fc14d4365c7add66"},
-    {file = "mypy-1.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f1478736fcebb90f97e40aff11a5f253af890c845ee0c850fe80aa060a267c6"},
-    {file = "mypy-1.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:42419861b43e6962a649068a61f4a4839205a3ef525b858377a960b9e2de6e0d"},
-    {file = "mypy-1.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:2b5b6c721bd4aabaadead3a5e6fa85c11c6c795e0c81a7215776ef8afc66de02"},
-    {file = "mypy-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5c1538c38584029352878a0466f03a8ee7547d7bd9f641f57a0f3017a7c905b8"},
-    {file = "mypy-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4ef4be7baf08a203170f29e89d79064463b7fc7a0908b9d0d5114e8009c3a259"},
-    {file = "mypy-1.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7178def594014aa6c35a8ff411cf37d682f428b3b5617ca79029d8ae72f5402b"},
-    {file = "mypy-1.8.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ab3c84fa13c04aeeeabb2a7f67a25ef5d77ac9d6486ff33ded762ef353aa5592"},
-    {file = "mypy-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:99b00bc72855812a60d253420d8a2eae839b0afa4938f09f4d2aa9bb4654263a"},
-    {file = "mypy-1.8.0-py3-none-any.whl", hash = "sha256:538fd81bb5e430cc1381a443971c0475582ff9f434c16cd46d2c66763ce85d9d"},
-    {file = "mypy-1.8.0.tar.gz", hash = "sha256:6ff8b244d7085a0b425b56d327b480c3b29cafbd2eff27316a004f9a7391ae07"},
+    {file = "mypy-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f8a67616990062232ee4c3952f41c779afac41405806042a8126fe96e098419f"},
+    {file = "mypy-1.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d357423fa57a489e8c47b7c85dfb96698caba13d66e086b412298a1a0ea3b0ed"},
+    {file = "mypy-1.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49c87c15aed320de9b438ae7b00c1ac91cd393c1b854c2ce538e2a72d55df150"},
+    {file = "mypy-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:48533cdd345c3c2e5ef48ba3b0d3880b257b423e7995dada04248725c6f77374"},
+    {file = "mypy-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:4d3dbd346cfec7cb98e6cbb6e0f3c23618af826316188d587d1c1bc34f0ede03"},
+    {file = "mypy-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:653265f9a2784db65bfca694d1edd23093ce49740b2244cde583aeb134c008f3"},
+    {file = "mypy-1.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3a3c007ff3ee90f69cf0a15cbcdf0995749569b86b6d2f327af01fd1b8aee9dc"},
+    {file = "mypy-1.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2418488264eb41f69cc64a69a745fad4a8f86649af4b1041a4c64ee61fc61129"},
+    {file = "mypy-1.9.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:68edad3dc7d70f2f17ae4c6c1b9471a56138ca22722487eebacfd1eb5321d612"},
+    {file = "mypy-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:85ca5fcc24f0b4aeedc1d02f93707bccc04733f21d41c88334c5482219b1ccb3"},
+    {file = "mypy-1.9.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aceb1db093b04db5cd390821464504111b8ec3e351eb85afd1433490163d60cd"},
+    {file = "mypy-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0235391f1c6f6ce487b23b9dbd1327b4ec33bb93934aa986efe8a9563d9349e6"},
+    {file = "mypy-1.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4d5ddc13421ba3e2e082a6c2d74c2ddb3979c39b582dacd53dd5d9431237185"},
+    {file = "mypy-1.9.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:190da1ee69b427d7efa8aa0d5e5ccd67a4fb04038c380237a0d96829cb157913"},
+    {file = "mypy-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:fe28657de3bfec596bbeef01cb219833ad9d38dd5393fc649f4b366840baefe6"},
+    {file = "mypy-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e54396d70be04b34f31d2edf3362c1edd023246c82f1730bbf8768c28db5361b"},
+    {file = "mypy-1.9.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5e6061f44f2313b94f920e91b204ec600982961e07a17e0f6cd83371cb23f5c2"},
+    {file = "mypy-1.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a10926e5473c5fc3da8abb04119a1f5811a236dc3a38d92015cb1e6ba4cb9e"},
+    {file = "mypy-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b685154e22e4e9199fc95f298661deea28aaede5ae16ccc8cbb1045e716b3e04"},
+    {file = "mypy-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:5d741d3fc7c4da608764073089e5f58ef6352bedc223ff58f2f038c2c4698a89"},
+    {file = "mypy-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:587ce887f75dd9700252a3abbc9c97bbe165a4a630597845c61279cf32dfbf02"},
+    {file = "mypy-1.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f88566144752999351725ac623471661c9d1cd8caa0134ff98cceeea181789f4"},
+    {file = "mypy-1.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61758fabd58ce4b0720ae1e2fea5cfd4431591d6d590b197775329264f86311d"},
+    {file = "mypy-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e49499be624dead83927e70c756970a0bc8240e9f769389cdf5714b0784ca6bf"},
+    {file = "mypy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:571741dc4194b4f82d344b15e8837e8c5fcc462d66d076748142327626a1b6e9"},
+    {file = "mypy-1.9.0-py3-none-any.whl", hash = "sha256:a260627a570559181a9ea5de61ac6297aa5af202f06fd7ab093ce74e7181e43e"},
+    {file = "mypy-1.9.0.tar.gz", hash = "sha256:3cc5da0127e6a478cddd906068496a97a7618a21ce9b54bde5bf7e539c7af974"},
 ]
 
 [package.dependencies]
@@ -2484,13 +2485,13 @@ et-xmlfile = "*"
 
 [[package]]
 name = "packaging"
-version = "23.2"
+version = "24.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
-    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
+    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
 ]
 
 [[package]]
@@ -3053,13 +3054,13 @@ tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pyopenssl"
-version = "24.0.0"
+version = "24.1.0"
 description = "Python wrapper module around the OpenSSL library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyOpenSSL-24.0.0-py3-none-any.whl", hash = "sha256:ba07553fb6fd6a7a2259adb9b84e12302a9a8a75c44046e8bb5d3e5ee887e3c3"},
-    {file = "pyOpenSSL-24.0.0.tar.gz", hash = "sha256:6aa33039a93fffa4563e655b61d11364d01264be8ccb49906101e02a334530bf"},
+    {file = "pyOpenSSL-24.1.0-py3-none-any.whl", hash = "sha256:17ed5be5936449c5418d1cd269a1a9e9081bc54c17aed272b45856a3d3dc86ad"},
+    {file = "pyOpenSSL-24.1.0.tar.gz", hash = "sha256:cabed4bfaa5df9f1a16c0ef64a0cb65318b5cd077a7eda7d6970131ca2f41a6f"},
 ]
 
 [package.dependencies]
@@ -3067,17 +3068,17 @@ cryptography = ">=41.0.5,<43"
 
 [package.extras]
 docs = ["sphinx (!=5.2.0,!=5.2.0.post0,!=7.2.5)", "sphinx-rtd-theme"]
-test = ["flaky", "pretend", "pytest (>=3.0.1)"]
+test = ["pretend", "pytest (>=3.0.1)", "pytest-rerunfailures"]
 
 [[package]]
 name = "pytest"
-version = "8.0.2"
+version = "8.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.0.2-py3-none-any.whl", hash = "sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096"},
-    {file = "pytest-8.0.2.tar.gz", hash = "sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd"},
+    {file = "pytest-8.1.1-py3-none-any.whl", hash = "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7"},
+    {file = "pytest-8.1.1.tar.gz", hash = "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044"},
 ]
 
 [package.dependencies]
@@ -3085,11 +3086,11 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=1.3.0,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+pluggy = ">=1.4,<2.0"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-calamine"
@@ -3296,7 +3297,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -3474,13 +3474,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-oauthlib"
-version = "1.3.1"
+version = "1.4.0"
 description = "OAuthlib authentication support for Requests."
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
-    {file = "requests-oauthlib-1.3.1.tar.gz", hash = "sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a"},
-    {file = "requests_oauthlib-1.3.1-py2.py3-none-any.whl", hash = "sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5"},
+    {file = "requests-oauthlib-1.4.0.tar.gz", hash = "sha256:acee623221e4a39abcbb919312c8ff04bd44e7e417087fb4bd5e2a2f53d5e79a"},
+    {file = "requests_oauthlib-1.4.0-py2.py3-none-any.whl", hash = "sha256:7a3130d94a17520169e38db6c8d75f2c974643788465ecc2e4b36d288bf13033"},
 ]
 
 [package.dependencies]
@@ -4183,18 +4183,18 @@ files = [
 
 [[package]]
 name = "traitlets"
-version = "5.14.1"
+version = "5.14.2"
 description = "Traitlets Python configuration system"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "traitlets-5.14.1-py3-none-any.whl", hash = "sha256:2e5a030e6eff91737c643231bfcf04a65b0132078dad75e4936700b213652e74"},
-    {file = "traitlets-5.14.1.tar.gz", hash = "sha256:8585105b371a04b8316a43d5ce29c098575c2e477850b62b848b964f1444527e"},
+    {file = "traitlets-5.14.2-py3-none-any.whl", hash = "sha256:fcdf85684a772ddeba87db2f398ce00b40ff550d1528c03c14dbf6a02003cd80"},
+    {file = "traitlets-5.14.2.tar.gz", hash = "sha256:8cdd83c040dab7d1dee822678e5f5d100b514f7b72b01615b26fc5718916fdf9"},
 ]
 
 [package.extras]
 docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
-test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,<7.5)", "pytest-mock", "pytest-mypy-testing"]
+test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,<8.1)", "pytest-mock", "pytest-mypy-testing"]
 
 [[package]]
 name = "typeguard"
@@ -4475,4 +4475,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "9766879dbfcd5bb6c89977f7a44becfa5dd3a223a8de2035c0e23b7e51febe1b"
+content-hash = "b86637d8d9086a14792c121acc400753d487a3e7f97efca384964c3ce41f4b1b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dapla-toolbelt = "^2.0.8"
 uuid = "^1.30"
 ipykernel = "^6.29.3"
 pandas = "^2.2.1"
-parameterized = "^0.9.0"
+parameterized = {extras = ["typed"], version = "^0.9.0"}
 
 [tool.poetry.group.dev.dependencies]
 Pygments = ">=2.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ sphinx-click = ">=3.0.2"
 typeguard = ">=2.13.3"
 xdoctest = { extras = ["colors"], version = ">=0.15.10" }
 myst-parser = { version = ">=0.16.1" }
-parameterized = "^0.9.0"
+parameterized = {extras = ["typed"], version = "^0.9.0"}
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dapla-toolbelt = "^2.0.8"
 uuid = "^1.30"
 ipykernel = "^6.29.3"
 pandas = "^2.2.1"
+parameterized = "^0.9.0"
 
 [tool.poetry.group.dev.dependencies]
 Pygments = ">=2.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ show_missing = true
 fail_under = 50
 
 [tool.mypy]
-strict = false
+strict = true
 warn_unreachable = true
 pretty = true
 show_column_numbers = true
@@ -87,7 +87,6 @@ module = [
     "google.cloud.*",
     "pandas.*",
     "pyarrow.*",
-    "parameterized.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ show_missing = true
 fail_under = 50
 
 [tool.mypy]
-strict = true
+strict = false
 warn_unreachable = true
 pretty = true
 show_column_numbers = true
@@ -87,6 +87,7 @@ module = [
     "google.cloud.*",
     "pandas.*",
     "pyarrow.*",
+    "parameterized.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dapla-toolbelt = "^2.0.8"
 uuid = "^1.30"
 ipykernel = "^6.29.3"
 pandas = "^2.2.1"
-parameterized = {extras = ["typed"], version = "^0.9.0"}
 
 [tool.poetry.group.dev.dependencies]
 Pygments = ">=2.10.0"
@@ -52,6 +51,7 @@ sphinx-click = ">=3.0.2"
 typeguard = ">=2.13.3"
 xdoctest = { extras = ["colors"], version = ">=0.15.10" }
 myst-parser = { version = ">=0.16.1" }
+parameterized = "^0.9.0"
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dapla-toolbelt = "^2.0.8"
 uuid = "^1.30"
 ipykernel = "^6.29.3"
 pandas = "^2.2.1"
+parameterized = {extras = ["typed"], version = "^0.9.0"}
 
 [tool.poetry.group.dev.dependencies]
 Pygments = ">=2.10.0"
@@ -51,7 +52,6 @@ sphinx-click = ">=3.0.2"
 typeguard = ">=2.13.3"
 xdoctest = { extras = ["colors"], version = ">=0.15.10" }
 myst-parser = { version = ">=0.16.1" }
-parameterized = {extras = ["typed"], version = "^0.9.0"}
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ show_missing = true
 fail_under = 50
 
 [tool.mypy]
-strict = false
+strict = true
 warn_unreachable = true
 pretty = true
 show_column_numbers = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ module = [
     "google.cloud.*",
     "pandas.*",
     "pyarrow.*",
+    "parameterized.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ show_missing = true
 fail_under = 50
 
 [tool.mypy]
-strict = true
+strict = false
 warn_unreachable = true
 pretty = true
 show_column_numbers = true

--- a/src/eimerdb/functions.py
+++ b/src/eimerdb/functions.py
@@ -85,6 +85,10 @@ def arrow_schema_from_json(json_schema: list[dict[str, Any]]) -> pa.Schema:
             unit_end = data_type.find(")")
             unit = data_type[unit_start:unit_end]
             field_type = pa.timestamp(unit)
+        elif "dictionary" in data_type:
+            field_type = getattr(pa, data_type)(
+                field_dict["indices"], field_dict["values"]
+            )
         else:
             field_type = getattr(pa, data_type)()
 

--- a/src/eimerdb/instance.py
+++ b/src/eimerdb/instance.py
@@ -308,7 +308,7 @@ class EimerDBInstance:
             table_name (str): The name of the table for which changes are to be retrieved.
 
         Returns:
-            DataFrame: A pandas DataFrame containing the changes for the specified table.
+            Table: A pyarrow table containing the changes for the specified table.
         """
         path = self.tables[table_name][TABLE_PATH_KEY]
 

--- a/src/eimerdb/instance.py
+++ b/src/eimerdb/instance.py
@@ -330,6 +330,7 @@ class EimerDBInstance:
 
         Args:
             table_name (str): The name of the table for which changes are to be retrieved.
+            raw (bool): Indicates whether to retrieve the raw schema.
 
         Returns:
             DataFrame: A pandas DataFrame containing the changes for the specified table.
@@ -386,6 +387,7 @@ class EimerDBInstance:
 
         Args:
             table_name (str): The name of the table.
+            raw (bool): Indicates whether to retrieve the raw schema.
         """
         if raw is True:
             suffix = "/_raw"

--- a/src/eimerdb/instance.py
+++ b/src/eimerdb/instance.py
@@ -25,7 +25,7 @@ from dapla import AuthClient
 from dapla import FileClient
 from gcsfs import GCSFileSystem
 from google.cloud import storage
-from pandas import DataFrame
+from pyarrow import Table
 
 from .functions import APPLICATION_JSON
 from .functions import arrow_schema_from_json
@@ -301,7 +301,7 @@ class EimerDBInstance:
         )
         print("Data successfully inserted!")
 
-    def get_changes(self, table_name: str) -> DataFrame:
+    def get_changes(self, table_name: str) -> Table:
         """Retrieve changes for a given table.
 
         Args:
@@ -322,7 +322,7 @@ class EimerDBInstance:
             filesystem=fs,
         )
 
-        df_changes: DataFrame = dataset.to_table()
+        df_changes: Table = dataset.to_table()
         return df_changes
 
     def get_inserts(self, table_name: str, raw: bool) -> pa.Table:

--- a/src/eimerdb/instance.py
+++ b/src/eimerdb/instance.py
@@ -27,15 +27,15 @@ from gcsfs import GCSFileSystem
 from google.cloud import storage
 from pandas import DataFrame
 
-from functions import APPLICATION_JSON
-from functions import arrow_schema_from_json
-from functions import get_datetime
-from functions import get_initials
-from functions import get_json
-from functions import parse_sql_query
-from query import filter_partitions
-from query import get_partitioned_files
-from query import update_pyarrow_table
+from .functions import APPLICATION_JSON
+from .functions import arrow_schema_from_json
+from .functions import get_datetime
+from .functions import get_initials
+from .functions import get_json
+from .functions import parse_sql_query
+from .query import filter_partitions
+from .query import get_partitioned_files
+from .query import update_pyarrow_table
 
 logger = logging.getLogger(__name__)
 

--- a/src/eimerdb/instance.py
+++ b/src/eimerdb/instance.py
@@ -27,15 +27,15 @@ from gcsfs import GCSFileSystem
 from google.cloud import storage
 from pandas import DataFrame
 
-from .functions import APPLICATION_JSON
-from .functions import arrow_schema_from_json
-from .functions import get_datetime
-from .functions import get_initials
-from .functions import get_json
-from .functions import parse_sql_query
-from .query import filter_partitions
-from .query import get_partitioned_files
-from .query import update_pyarrow_table
+from functions import APPLICATION_JSON
+from functions import arrow_schema_from_json
+from functions import get_datetime
+from functions import get_initials
+from functions import get_json
+from functions import parse_sql_query
+from query import filter_partitions
+from query import get_partitioned_files
+from query import update_pyarrow_table
 
 logger = logging.getLogger(__name__)
 
@@ -301,7 +301,7 @@ class EimerDBInstance:
         )
         print("Data successfully inserted!")
 
-    def get_changes(self, table_name: str) -> DataFrame:
+    def get_changes(self, table_name: str) -> pa.Table:
         """Retrieve changes for a given table.
 
         Args:
@@ -318,11 +318,41 @@ class EimerDBInstance:
             f"{self.bucket}/{path}_changes/",
             format="parquet",
             partitioning="hive",
+            schema=self._get_arrow_schema(table_name, True),
             filesystem=fs,
         )
 
-        df_changes: DataFrame = dataset.to_table().to_pandas()
+        df_changes: DataFrame = dataset.to_table()
         return df_changes
+
+    def get_inserts(self, table_name: str, raw: bool) -> pa.Table:
+        """Retrieve changes for a given table.
+
+        Args:
+            table_name (str): The name of the table for which changes are to be retrieved.
+
+        Returns:
+            DataFrame: A pandas DataFrame containing the changes for the specified table.
+        """
+        if raw is True:
+            suffix = "_raw"
+        else:
+            suffix = ""
+
+        path = self.tables[table_name][TABLE_PATH_KEY] + suffix
+
+        fs = FileClient.get_gcs_file_system()
+        # noinspection PyTypeChecker
+        dataset = ds.dataset(
+            f"{self.bucket}/{path}/",
+            format="parquet",
+            partitioning="hive",
+            schema=self._get_arrow_schema(table_name, raw),
+            filesystem=fs,
+        )
+
+        df_inserts: pa.Table = dataset.to_table()
+        return df_inserts
 
     def combine_changes(self, table_name: str) -> None:
         """Combines the files containing the changes of the table into one file.
@@ -339,16 +369,49 @@ class EimerDBInstance:
 
         # noinspection PyTypeChecker
         pq.write_to_dataset(
-            table=pa.Table.from_pandas(self.get_changes(table_name)),
+            table=self.get_changes(table_name),
             root_path=f"gs://{self.bucket}/{source_folder}",
             partition_cols=partitions,
             basename_template=f"merged_commit_{uuid4()}_{{i}}.parquet",
+            schema=self._get_arrow_schema(table_name, True),
             filesystem=FileClient.get_gcs_file_system(),
         )
         for blob in blobs_to_delete:
             blob.delete()
 
         print("The changes were successfully merged into one file per partition!")
+
+    def combine_inserts(self, table_name: str, raw: bool) -> None:
+        """Combines the files containing the inserts of the table into one file.
+
+        Args:
+            table_name (str): The name of the table.
+        """
+        if raw is True:
+            suffix = "/_raw"
+        else:
+            suffix = ""
+
+        client = storage.Client(credentials=AuthClient.fetch_google_credentials())
+        bucket = client.bucket(self.bucket)
+
+        partitions = self.tables[table_name][PARTITION_COLUMNS_KEY]
+        source_folder = self.tables[table_name][TABLE_PATH_KEY] + suffix
+        blobs_to_delete = list(bucket.list_blobs(prefix=source_folder))
+
+        # noinspection PyTypeChecker
+        pq.write_to_dataset(
+            table=self.get_inserts(table_name, raw),
+            root_path=f"gs://{self.bucket}/{source_folder}",
+            partition_cols=partitions,
+            basename_template=f"merged_commit_{uuid4()}_{{i}}.parquet",
+            schema=self._get_arrow_schema(table_name, raw),
+            filesystem=FileClient.get_gcs_file_system(),
+        )
+        for blob in blobs_to_delete:
+            blob.delete()
+
+        print("The inserts were successfully merged into one file per partition!")
 
     def _get_arrow_schema(
         self,
@@ -469,6 +532,7 @@ class EimerDBInstance:
             root_path=f"gs://{self.bucket}/{table_path}",
             partition_cols=partitions,
             basename_template=f"commit_{uuid4()}_{{i}}.parquet",
+            schema=self._get_arrow_schema(table_name, True),
             filesystem=fs,
         )
         return f"{df_updates_commits.shape[0]} rows updated by {get_initials()}"
@@ -523,6 +587,7 @@ class EimerDBInstance:
             root_path=f"gs://{self.bucket}/{table_path}",
             partition_cols=partitions,
             basename_template=filename,
+            schema=self._get_arrow_schema(table_name, True),
             filesystem=fs,
         )
         return f"{df_deletions_len} rows deleted by {get_initials()}"

--- a/src/eimerdb/instance.py
+++ b/src/eimerdb/instance.py
@@ -301,7 +301,7 @@ class EimerDBInstance:
         )
         print("Data successfully inserted!")
 
-    def get_changes(self, table_name: str) -> pa.Table:
+    def get_changes(self, table_name: str) -> DataFrame:
         """Retrieve changes for a given table.
 
         Args:

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -285,7 +285,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             {"row_id": ["1"], "field1": [1]}, schema=schema
         )
 
-        mock_get_changes.return_value = pexpected_table
+        mock_get_changes.return_value = expected_table
 
         # Mock the return values of other dependencies
         mock_uuid4.return_value = "mocked_uuid"

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -234,8 +234,8 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     @patch("eimerdb.instance.ds.dataset")
     @parameterized.expand(
         [
-            (True,),
-            (False,),
+            True,
+            False,
         ]
     )
     def test_get_inserts(self, mock_dataset: Mock, mock_fs: Mock, raw: bool) -> None:
@@ -279,7 +279,13 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         mock_fetch_credentials: Mock,
     ) -> None:
         # Mock the return value of get_changes
-        mock_get_changes.return_value = pd.DataFrame([{"row_id": "1", "field1": 1}])
+        schema = pa.schema([("row_id", pa.string()), ("field1", pa.int64())])
+
+        expected_table = pa.Table.from_pydict(
+            {"row_id": ["1"], "field1": [1]}, schema=schema
+        )
+
+        mock_get_changes.return_value = pexpected_table
 
         # Mock the return values of other dependencies
         mock_uuid4.return_value = "mocked_uuid"

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -206,7 +206,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
     @patch("eimerdb.instance.ds.dataset")
     def test_get_changes(self, mock_dataset: Mock, _: Mock) -> None:
-        schema = pa.schema([('row_id', pa.string()), ('field1', pa.int64())])
+        schema = pa.schema([("row_id", pa.string()), ("field1", pa.int64())])
 
         expected_table = pa.Table.from_pydict(
             {"row_id": ["1"], "field1": [1]}, schema=schema
@@ -239,10 +239,10 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         ]
     )
     def test_get_inserts(self, mock_dataset: Mock, mock_fs: Mock, raw: bool) -> None:
-        schema = pa.schema([('row_id', pa.string()), ('field1', pa.int64())])
+        schema = pa.schema([("row_id", pa.string()), ("field1", pa.int64())])
 
         expected_table = pa.Table.from_pydict(
-            {'row_id': ['1'], 'field1': [1]}, schema=schema
+            {"row_id": ["1"], "field1": [1]}, schema=schema
         )
 
         dataset = Mock(spec=ds.Dataset)

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -253,8 +253,8 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
 
     @parameterized.expand(
         [
-            True,
-            False,
+            (True,),
+            (False,),
         ]
     )
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
@@ -383,8 +383,8 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
 
     @parameterized.expand(
         [
-            True,
-            False,
+            (True,),
+            (False,),
         ]
     )
     @patch("eimerdb.instance.AuthClient.fetch_google_credentials")

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -232,7 +232,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
 
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
     @patch("eimerdb.instance.ds.dataset")
-    @parameterized.expand(
+    @parameterized(
         [
             (True,),
             (False,),
@@ -319,7 +319,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     @patch("eimerdb.instance.uuid4")
     @patch("eimerdb.instance.pq.write_to_dataset")
     @patch("eimerdb.instance.EimerDBInstance.get_changes")
-    @parameterized.expand(
+    @parameterized(
         [
             (True,),
             (False,),

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -217,7 +217,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         )
 
         dataset = Mock(spec=ds.Dataset)
-        dataset.to_table.return_value.to_pandas.return_value = expected_df
+        dataset.to_table.return_value = expected_table
         mock_dataset.return_value = dataset
 
         # Call the get_changes method
@@ -254,7 +254,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         )
 
         dataset = Mock(spec=ds.Dataset)
-        dataset.to_table.return_value = expected_df
+        dataset.to_table.return_value = expected_table
         mock_dataset.return_value = dataset
 
         inserts_table = self.instance.get_inserts("table1", raw=raw)
@@ -262,7 +262,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         suffix = "_raw" if raw else ""
 
         mock_dataset.assert_called_once_with(
-            f"{self.instance.bucket}/{self.instance.tables['table1'][instance.TABLE_PATH_KEY]}{suffix}/",
+            f"test_bucket/path/to/eimer/table1{suffix}/",
             format="parquet",
             partitioning="hive",
             schema=self.instance._get_arrow_schema("table1", raw),

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -1,4 +1,3 @@
-from parameterized import parameterized
 import unittest
 from unittest.mock import ANY
 from unittest.mock import MagicMock
@@ -10,6 +9,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.dataset as ds
 from google.cloud.storage import Blob
+from parameterized import parameterized  # type: ignore
 
 from eimerdb.instance import EimerDBInstance
 

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -303,7 +303,6 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             f"test_bucket/path/to/eimer/table1{suffix}/",
             format="parquet",
             partitioning="hive",
-            schema=self.instance._get_arrow_schema("table1", raw),
             filesystem=ANY,
         )
 
@@ -374,7 +373,6 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             root_path="gs://test_bucket/path/to/eimer/table1_changes",
             partition_cols=None,
             basename_template="merged_commit_mocked_uuid_{i}.parquet",
-            schema=schema,
             filesystem=ANY,
         )
         blob_1.delete.assert_called_once()
@@ -458,7 +456,6 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             root_path=f"gs://test_bucket/path/to/eimer/table1{suffix}",
             partition_cols=None,
             basename_template="merged_insert_mocked_uuid_{i}.parquet",
-            schema=schema,
             filesystem=ANY,
         )
         blob_1.delete.assert_called_once()

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -316,15 +316,18 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         mock_fetch_credentials: Mock,
     ) -> None:
         # Mock the return value of get_changes
-        schema = pa.schema(
-            [
-                ("row_id", pa.string(), label="Unique row ID"),
-                ("field1", pa.int64(), label="Field 1"),
-                ("user", pa.string()),
-                ("datetime", pa.string()),
-                ("operation", pa.string()),
-            ]
-        )
+        schema_fields = [
+            pa.field("row_id", pa.string(), metadata={"label": "Unique row ID"}),
+            pa.field("field1", pa.int64(), metadata={"label": "Field1"}),
+        ]
+
+        schema_fields.extend([
+            pa.field("user", pa.string()),
+            pa.field("datetime", pa.string()),
+            pa.field("operation", pa.string()),
+        ])
+
+        schema = pa.schema(schema_fields)
 
         expected_table = pa.Table.from_pydict(
             {
@@ -390,15 +393,15 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     ) -> None:
         # Mock the return value of get_changes
         schema_fields = [
-            ("row_id", pa.string(), label="Unique row ID"),
-            ("field1", pa.int64(), label="Field1"),
+            pa.field("row_id", pa.string(), metadata={"label": "Unique row ID"}),
+            pa.field("field1", pa.int64(), metadata={"label": "Field1"}),
         ]
 
         if not raw:
             schema_fields.extend([
-                ("user", pa.string()),
-                ("datetime", pa.string()),
-                ("operation", pa.string()),
+                pa.field("user", pa.string()),
+                pa.field("datetime", pa.string()),
+                pa.field("operation", pa.string()),
             ])
 
         schema = pa.schema(schema_fields)

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -232,7 +232,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
 
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
     @patch("eimerdb.instance.ds.dataset")
-    @parameterized.expand(
+    @parameterized.expand(  # type: ignore
         [
             (True,),
             (False,),
@@ -319,7 +319,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     @patch("eimerdb.instance.uuid4")
     @patch("eimerdb.instance.pq.write_to_dataset")
     @patch("eimerdb.instance.EimerDBInstance.get_changes")
-    @parameterized.expand(
+    @parameterized.expand(  # Type: Ignore
         [
             (True,),
             (False,),
@@ -327,7 +327,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     )
     def test_combine_inserts(
         self,
-        mock_get_changes: Mock,
+        mock_get_inserts: Mock,
         mock_write_to_dataset: Mock,
         mock_uuid4: Mock,
         _: Mock,

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -206,15 +206,18 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
     @patch("eimerdb.instance.ds.dataset")
     def test_get_changes(self, mock_dataset: Mock, _: Mock) -> None:
-        schema = pa.schema(
-            [
-                ("row_id", pa.string(), label="Unique row ID"),
-                ("field1", pa.int64(), label="Field 1"),
-                ("user", pa.string()),
-                ("datetime", pa.string()),
-                ("operation", pa.string()),
-            ]
-        )
+        schema_fields = [
+            pa.field("row_id", pa.string(), metadata={"label": "Unique row ID"}),
+            pa.field("field1", pa.int64(), metadata={"label": "Field1"}),
+        ]
+
+        schema_fields.extend([
+            pa.field("user", pa.string()),
+            pa.field("datetime", pa.string()),
+            pa.field("operation", pa.string()),
+        ])
+
+        schema = pa.schema(schema_fields)
 
         expected_table = pa.Table.from_pydict(
             {
@@ -226,6 +229,8 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             },
             schema=schema,
         )
+
+        expected_table = pa.Table.from_pydict(expected_data, schema=schema)
 
         dataset = Mock(spec=ds.Dataset)
         dataset.to_table.return_value = expected_table
@@ -255,15 +260,15 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     )
     def test_get_inserts(self, mock_dataset: Mock, raw: bool) -> None:
         schema_fields = [
-            ("row_id", pa.string(), label="Unique row ID"),
-            ("field1", pa.int64(), label="Field 1"),
+            pa.field("row_id", pa.string(), metadata={"label": "Unique row ID"}),
+            pa.field("field1", pa.int64(), metadata={"label": "Field1"}),
         ]
 
         if not raw:
             schema_fields.extend([
-                ("user", pa.string()),
-                ("datetime", pa.string()),
-                ("operation", pa.string()),
+                pa.field("user", pa.string()),
+                pa.field("datetime", pa.string()),
+                pa.field("operation", pa.string()),
             ])
 
         schema = pa.schema(schema_fields)

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -319,7 +319,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     @patch("eimerdb.instance.uuid4")
     @patch("eimerdb.instance.pq.write_to_dataset")
     @patch("eimerdb.instance.EimerDBInstance.get_changes")
-    @parameterized.expand(  # Type: Ignore
+    @parameterized.expand(  # type: ignore
         [
             (True,),
             (False,),

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -244,6 +244,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             "test_bucket/path/to/eimer/table1_changes/",
             format="parquet",
             partitioning="hive",
+            schema=self.instance._get_arrow_schema("table1", True),
             filesystem=ANY,
         )
 
@@ -303,6 +304,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             f"test_bucket/path/to/eimer/table1{suffix}/",
             format="parquet",
             partitioning="hive",
+            schema=self.instance._get_arrow_schema("table1", raw),
             filesystem=ANY,
         )
 
@@ -373,6 +375,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             root_path="gs://test_bucket/path/to/eimer/table1_changes",
             partition_cols=None,
             basename_template="merged_commit_mocked_uuid_{i}.parquet",
+            schema=self.instance._get_arrow_schema("table1", True),
             filesystem=ANY,
         )
         blob_1.delete.assert_called_once()
@@ -456,6 +459,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             root_path=f"gs://test_bucket/path/to/eimer/table1{suffix}",
             partition_cols=None,
             basename_template="merged_insert_mocked_uuid_{i}.parquet",
+            schema=self.instance._get_arrow_schema("table1", raw),
             filesystem=ANY,
         )
         blob_1.delete.assert_called_once()

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -230,8 +230,6 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             schema=schema,
         )
 
-        expected_table = pa.Table.from_pydict(expected_data, schema=schema)
-
         dataset = Mock(spec=ds.Dataset)
         dataset.to_table.return_value = expected_table
         mock_dataset.return_value = dataset

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -289,13 +289,16 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             ]
         )
 
-        expected_table = pa.Table.from_pydict({
-            "row_id": ["1"],
-            "field1": [1],
-            "user": ["user42"],
-            "datetime": ["2024-03-12T12:00:00"],
-            "operation": ["insert"]
-        }, schema=schema)
+        expected_table = pa.Table.from_pydict(
+            {
+                "row_id": ["1"],
+                "field1": [1],
+                "user": ["user42"],
+                "datetime": ["2024-03-12T12:00:00"],
+                "operation": ["insert"],
+            },
+            schema=schema,
+        )
 
         mock_get_changes.return_value = expected_table
 
@@ -358,13 +361,16 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             ]
         )
 
-        expected_table = pa.Table.from_pydict({
-            "row_id": ["1"],
-            "field1": [1],
-            "user": ["user42"],
-            "datetime": ["2024-03-12T12:00:00"],
-            "operation": ["insert"]
-        }, schema=schema)
+        expected_table = pa.Table.from_pydict(
+            {
+                "row_id": ["1"],
+                "field1": [1],
+                "user": ["user42"],
+                "datetime": ["2024-03-12T12:00:00"],
+                "operation": ["insert"],
+            },
+            schema=schema,
+        )
 
         mock_get_inserts.return_value = expected_table
 

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -208,7 +208,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     def test_get_changes(self, mock_dataset: Mock, _: Mock) -> None:
         schema_fields = [
             pa.field("row_id", pa.string(), metadata={"label": "Unique row ID"}),
-            pa.field("field1", pa.int64(), metadata={"label": "Field1"}),
+            pa.field("field1", pa.int8(), metadata={"label": "Field1"}),
         ]
 
         schema_fields.extend(
@@ -261,7 +261,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     def test_get_inserts(self, mock_dataset: Mock, raw: bool) -> None:
         schema_fields = [
             pa.field("row_id", pa.string(), metadata={"label": "Unique row ID"}),
-            pa.field("field1", pa.int64(), metadata={"label": "Field1"}),
+            pa.field("field1", pa.int8(), metadata={"label": "Field1"}),
         ]
 
         if not raw:
@@ -327,7 +327,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         # Mock the return value of get_changes
         schema_fields = [
             pa.field("row_id", pa.string(), metadata={"label": "Unique row ID"}),
-            pa.field("field1", pa.int64(), metadata={"label": "Field1"}),
+            pa.field("field1", pa.int8(), metadata={"label": "Field1"}),
         ]
 
         schema_fields.extend(

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -238,7 +238,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             (False,),
         ]
     )
-    def test_get_inserts(self, mock_dataset: Mock, mock_fs: Mock, raw: bool) -> None:
+    def test_get_inserts(self, mock_dataset: Mock, raw: bool) -> None:
         schema = pa.schema([("row_id", pa.string()), ("field1", pa.int64())])
 
         expected_table = pa.Table.from_pydict(

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -1,3 +1,4 @@
+from parameterized import parameterized
 import unittest
 from unittest.mock import ANY
 from unittest.mock import MagicMock

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -205,8 +205,6 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
     @patch("eimerdb.instance.ds.dataset")
     def test_get_changes(self, mock_dataset: Mock, _: Mock) -> None:
-        data = [{"row_id": "1", "field1": 1}]
-
         schema = pa.schema([
             ('row_id', pa.string()),
             ('field1', pa.int64())
@@ -233,7 +231,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         )
 
         # Assert that the returned DataFrame is the same as the mock DataFrame
-        self.assertIs(expected_df, changes_df)
+        self.assertIs(expected_table, changes_df)
 
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
     @patch("eimerdb.instance.ds.dataset")
@@ -244,8 +242,6 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         ]
     )
     def test_get_inserts(self, mock_dataset: Mock, mock_fs: Mock, raw: bool) -> None:
-        data = [{"row_id": "1", "field1": 1}]
-
         schema = pa.schema([
             ('row_id', pa.string()),
             ('field1', pa.int64())
@@ -288,6 +284,51 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         _: Mock,
         mock_client: Mock,
         mock_fetch_credentials: Mock,
+    ) -> None:
+        # Mock the return value of get_changes
+        mock_get_changes.return_value = pd.DataFrame([{"row_id": "1", "field1": 1}])
+
+        # Mock the return values of other dependencies
+        mock_uuid4.return_value = "mocked_uuid"
+
+        blob_1 = Mock(spec=Blob)
+        blob_2 = Mock(spec=Blob)
+
+        mock_fetch_credentials.return_value = "token"
+        mock_client.return_value.bucket.return_value.list_blobs.return_value = [
+            blob_1,
+            blob_2,
+        ]
+
+        # Call the merge_changes method
+        self.instance.combine_changes("table1")
+
+        # Assert that the dependencies are called with the expected arguments
+        mock_write_to_dataset.assert_called_once_with(
+            table=pa.Table.from_pandas(mock_get_changes.return_value),
+            root_path="gs://test_bucket/path/to/eimer/table1_changes",
+            partition_cols=None,
+            basename_template="merged_commit_mocked_uuid_{i}.parquet",
+            filesystem=ANY,
+        )
+        blob_1.delete.assert_called_once()
+        blob_2.delete.assert_called_once()
+
+    @patch("eimerdb.instance.AuthClient.fetch_google_credentials")
+    @patch("eimerdb.instance.storage.Client")
+    @patch("eimerdb.instance.FileClient.get_gcs_file_system")
+    @patch("eimerdb.instance.uuid4")
+    @patch("eimerdb.instance.pq.write_to_dataset")
+    @patch("eimerdb.instance.EimerDBInstance.get_changes")
+    def test_combine_inserts(
+        self,
+        mock_get_changes: Mock,
+        mock_write_to_dataset: Mock,
+        mock_uuid4: Mock,
+        _: Mock,
+        mock_client: Mock,
+        mock_fetch_credentials: Mock,
+        raw: bool,
     ) -> None:
         # Mock the return value of get_changes
         mock_get_changes.return_value = pd.DataFrame([{"row_id": "1", "field1": 1}])

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -211,11 +211,13 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             pa.field("field1", pa.int64(), metadata={"label": "Field1"}),
         ]
 
-        schema_fields.extend([
-            pa.field("user", pa.string()),
-            pa.field("datetime", pa.string()),
-            pa.field("operation", pa.string()),
-        ])
+        schema_fields.extend(
+            [
+                pa.field("user", pa.string()),
+                pa.field("datetime", pa.string()),
+                pa.field("operation", pa.string()),
+            ]
+        )
 
         schema = pa.schema(schema_fields)
 
@@ -263,11 +265,13 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         ]
 
         if not raw:
-            schema_fields.extend([
-                pa.field("user", pa.string()),
-                pa.field("datetime", pa.string()),
-                pa.field("operation", pa.string()),
-            ])
+            schema_fields.extend(
+                [
+                    pa.field("user", pa.string()),
+                    pa.field("datetime", pa.string()),
+                    pa.field("operation", pa.string()),
+                ]
+            )
 
         schema = pa.schema(schema_fields)
 
@@ -277,11 +281,13 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         }
 
         if not raw:
-            expected_data.update({
-                "user": ["user42"],
-                "datetime": ["2024-03-12T12:00:00"],
-                "operation": ["insert"],
-            })
+            expected_data.update(
+                {
+                    "user": ["user42"],
+                    "datetime": ["2024-03-12T12:00:00"],
+                    "operation": ["insert"],
+                }
+            )
 
         expected_table = pa.Table.from_pydict(expected_data, schema=schema)
 
@@ -324,11 +330,13 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             pa.field("field1", pa.int64(), metadata={"label": "Field1"}),
         ]
 
-        schema_fields.extend([
-            pa.field("user", pa.string()),
-            pa.field("datetime", pa.string()),
-            pa.field("operation", pa.string()),
-        ])
+        schema_fields.extend(
+            [
+                pa.field("user", pa.string()),
+                pa.field("datetime", pa.string()),
+                pa.field("operation", pa.string()),
+            ]
+        )
 
         schema = pa.schema(schema_fields)
 
@@ -401,11 +409,13 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         ]
 
         if not raw:
-            schema_fields.extend([
-                pa.field("user", pa.string()),
-                pa.field("datetime", pa.string()),
-                pa.field("operation", pa.string()),
-            ])
+            schema_fields.extend(
+                [
+                    pa.field("user", pa.string()),
+                    pa.field("datetime", pa.string()),
+                    pa.field("operation", pa.string()),
+                ]
+            )
 
         schema = pa.schema(schema_fields)
 
@@ -415,11 +425,13 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         }
 
         if not raw:
-            expected_data.update({
-                "user": ["user42"],
-                "datetime": ["2024-03-12T12:00:00"],
-                "operation": ["insert"],
-            })
+            expected_data.update(
+                {
+                    "user": ["user42"],
+                    "datetime": ["2024-03-12T12:00:00"],
+                    "operation": ["insert"],
+                }
+            )
 
         expected_table = pa.Table.from_pydict(expected_data, schema=schema)
 

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -206,14 +206,10 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
     @patch("eimerdb.instance.ds.dataset")
     def test_get_changes(self, mock_dataset: Mock, _: Mock) -> None:
-        schema = pa.schema([
-            ('row_id', pa.string()),
-            ('field1', pa.int64())
-        ])
+        schema = pa.schema([('row_id', pa.string()), ('field1', pa.int64())])
 
         expected_table = pa.Table.from_pydict(
-            {"row_id": ["1"], "field1": [1]},
-            schema=schema
+            {"row_id": ["1"], "field1": [1]}, schema=schema
         )
 
         dataset = Mock(spec=ds.Dataset)
@@ -243,14 +239,10 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         ]
     )
     def test_get_inserts(self, mock_dataset: Mock, mock_fs: Mock, raw: bool) -> None:
-        schema = pa.schema([
-            ('row_id', pa.string()),
-            ('field1', pa.int64())
-        ])
+        schema = pa.schema([('row_id', pa.string()), ('field1', pa.int64())])
 
         expected_table = pa.Table.from_pydict(
-            {'row_id': ['1'], 'field1': [1]},
-            schema=schema
+            {'row_id': ['1'], 'field1': [1]}, schema=schema
         )
 
         dataset = Mock(spec=ds.Dataset)

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -279,11 +279,23 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         mock_fetch_credentials: Mock,
     ) -> None:
         # Mock the return value of get_changes
-        schema = pa.schema([("row_id", pa.string()), ("field1", pa.int64())])
-
-        expected_table = pa.Table.from_pydict(
-            {"row_id": ["1"], "field1": [1]}, schema=schema
+        schema = pa.schema(
+            [
+                ("row_id", pa.string()),
+                ("field1", pa.int64()),
+                ("user", pa.string()),
+                ("datetime", pa.string()),
+                ("operation", pa.string()),
+            ]
         )
+
+        expected_table = pa.Table.from_pydict({
+            "row_id": ["1"],
+            "field1": [1],
+            "user": ["user42"],
+            "datetime": ["2024-03-12T12:00:00"],
+            "operation": ["insert"]
+        }, schema=schema)
 
         mock_get_changes.return_value = expected_table
 
@@ -336,11 +348,23 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         raw: bool,
     ) -> None:
         # Mock the return value of get_changes
-        schema = pa.schema([("row_id", pa.string()), ("field1", pa.int64())])
-
-        expected_table = pa.Table.from_pydict(
-            {"row_id": ["1"], "field1": [1]}, schema=schema
+        schema = pa.schema(
+            [
+                ("row_id", pa.string()),
+                ("field1", pa.int64()),
+                ("user", pa.string()),
+                ("datetime", pa.string()),
+                ("operation", pa.string()),
+            ]
         )
+
+        expected_table = pa.Table.from_pydict({
+            "row_id": ["1"],
+            "field1": [1],
+            "user": ["user42"],
+            "datetime": ["2024-03-12T12:00:00"],
+            "operation": ["insert"]
+        }, schema=schema)
 
         mock_get_inserts.return_value = expected_table
 
@@ -356,15 +380,15 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
             blob_2,
         ]
 
-        # Call the merge_changes method
-        self.instance.combine_changes("table1")
+        suffix = "_raw" if raw else ""
 
-        # Assert that the dependencies are called with the expected arguments
+        self.instance.combine_inserts("table1", raw)
+
         mock_write_to_dataset.assert_called_once_with(
             table=mock_get_inserts.return_value,
-            root_path="gs://test_bucket/path/to/eimer/table1_changes",
+            root_path=f"gs://test_bucket/path/to/eimer/table1{suffix}",
             partition_cols=None,
-            basename_template="merged_commit_mocked_uuid_{i}.parquet",
+            basename_template="merged_insert_mocked_uuid_{i}.parquet",
             filesystem=ANY,
         )
         blob_1.delete.assert_called_once()

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -304,7 +304,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
 
         # Assert that the dependencies are called with the expected arguments
         mock_write_to_dataset.assert_called_once_with(
-            table=pa.Table.from_pandas(mock_get_changes.return_value),
+            table=mock_get_changes.return_value,
             root_path="gs://test_bucket/path/to/eimer/table1_changes",
             partition_cols=None,
             basename_template="merged_commit_mocked_uuid_{i}.parquet",
@@ -336,7 +336,13 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
         raw: bool,
     ) -> None:
         # Mock the return value of get_changes
-        mock_get_changes.return_value = pd.DataFrame([{"row_id": "1", "field1": 1}])
+        schema = pa.schema([("row_id", pa.string()), ("field1", pa.int64())])
+
+        expected_table = pa.Table.from_pydict(
+            {"row_id": ["1"], "field1": [1]}, schema=schema
+        )
+
+        mock_get_inserts.return_value = expected_table
 
         # Mock the return values of other dependencies
         mock_uuid4.return_value = "mocked_uuid"
@@ -355,7 +361,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
 
         # Assert that the dependencies are called with the expected arguments
         mock_write_to_dataset.assert_called_once_with(
-            table=pa.Table.from_pandas(mock_get_changes.return_value),
+            table=mock_get_inserts.return_value,
             root_path="gs://test_bucket/path/to/eimer/table1_changes",
             partition_cols=None,
             basename_template="merged_commit_mocked_uuid_{i}.parquet",

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -234,8 +234,8 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     @patch("eimerdb.instance.ds.dataset")
     @parameterized.expand(
         [
-            True,
-            False,
+            (True,),
+            (False,),
         ]
     )
     def test_get_inserts(self, mock_dataset: Mock, mock_fs: Mock, raw: bool) -> None:
@@ -319,6 +319,12 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     @patch("eimerdb.instance.uuid4")
     @patch("eimerdb.instance.pq.write_to_dataset")
     @patch("eimerdb.instance.EimerDBInstance.get_changes")
+    @parameterized.expand(
+        [
+            (True,),
+            (False,),
+        ]
+    )
     def test_combine_inserts(
         self,
         mock_get_changes: Mock,

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -232,7 +232,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
 
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
     @patch("eimerdb.instance.ds.dataset")
-    @parameterized(
+    @parameterized.expand(
         [
             (True,),
             (False,),
@@ -319,7 +319,7 @@ class TestEimerDBInstanceAdminUser(unittest.TestCase):
     @patch("eimerdb.instance.uuid4")
     @patch("eimerdb.instance.pq.write_to_dataset")
     @patch("eimerdb.instance.EimerDBInstance.get_changes")
-    @parameterized(
+    @parameterized.expand(
         [
             (True,),
             (False,),

--- a/tests/test_instance_non_admin_user.py
+++ b/tests/test_instance_non_admin_user.py
@@ -56,7 +56,7 @@ class TestEimerDBInstanceNonAdminUser(unittest.TestCase):
             "Cannot create table. You are not an admin!", str(context.exception)
         )
 
-    def test_main_table_insert_non_admin(self) -> None:
+    def test_main_table_insert_non_admin_(self) -> None:
         # Test & Assertion
         with self.assertRaises(PermissionError) as context:
             self.instance.insert("table1", pd.DataFrame())

--- a/tests/test_instance_non_admin_user.py
+++ b/tests/test_instance_non_admin_user.py
@@ -56,7 +56,7 @@ class TestEimerDBInstanceNonAdminUser(unittest.TestCase):
             "Cannot create table. You are not an admin!", str(context.exception)
         )
 
-    def test_main_table_insert_non_admin_(self) -> None:
+    def test_main_table_insert_non_admin(self) -> None:
         # Test & Assertion
         with self.assertRaises(PermissionError) as context:
             self.instance.insert("table1", pd.DataFrame())


### PR DESCRIPTION
- Added a method for combining the inserts into one file per partition. If there are many insert-files, merging them to one file will improve query performance. 
- Changed the output of get_changes from pandas dataframe to pyarrow table.
- Added support for dictionary type in the schema.
- poetry update...
