### PR TITLE
Parts of code in instance.py is moved to instance_query_changes_worke…

### DIFF
--- a/src/eimerdb/abstract_db_instance.py
+++ b/src/eimerdb/abstract_db_instance.py
@@ -1,0 +1,191 @@
+from abc import ABC
+from abc import abstractmethod
+from typing import Any
+from typing import Optional
+from typing import Union
+
+import pandas as pd
+import pyarrow as pa
+
+from eimerdb.eimerdb_constants import PANDAS_OUTPUT_FORMAT
+
+
+class AbstractDbInstance(ABC):
+    """Abstract class for database instance.
+
+    All database instance classes must inherit from this class.
+    """
+
+    def __init__(
+        self,
+        bucket_name: str,
+        eimerdb_name: str,
+        path: str,
+        eimer_path: str,
+        created_by: str,
+        time_created: str,
+        tables: dict[str, Any],
+        users: dict[str, Any],
+        role_groups: dict[str, Any],
+        is_admin: bool,
+    ) -> None:
+        """Initialize AbstractDbInstance.
+
+        Args:
+            bucket_name (str): Name of the bucket.
+            eimerdb_name (str): Name of the EimerDB.
+            path (str): Path to the EimerDB configuration file.
+            eimer_path (str): Path to the EimerDB.
+            created_by (str): Name of the user who created the EimerDB.
+            time_created (str): Time when the EimerDB was created.
+            tables (dict): Dictionary containing the tables in the EimerDB.
+            users (dict): Dictionary containing the users in the EimerDB.
+            role_groups (dict): Dictionary containing the role groups in the EimerDB.
+            is_admin (bool): Indicates whether the current user is an admin.
+        """
+        self.bucket_name = bucket_name
+        self.eimerdb_name = eimerdb_name
+        self.path = path
+        self.eimer_path = eimer_path
+        self.created_by = created_by
+        self.time_created = time_created
+        self.tables = tables
+        self.users = users
+        self.role_groups = role_groups
+        self.is_admin = is_admin
+
+    @abstractmethod
+    def add_user(self, username: str, role: Any) -> None:
+        """Add a user with a specified role.
+
+        Args:
+            username (str): Name of the user to add.
+            role (Any): Role to assign (admin or user).
+
+        Raises:
+            PermissionError: If the user is not an admin.
+            ValueError: If the user already exists.
+        """
+
+    @abstractmethod
+    def remove_user(self, username: str) -> None:
+        """Remove a users access to the database.
+
+        Args:
+            username (str): Name of the user to remove.
+
+        Raises:
+            PermissionError: If the user is not an admin.
+            ValueError: If the user does not exist.
+        """
+
+    @abstractmethod
+    def create_table(
+        self,
+        table_name: str,
+        schema: list[dict[str, Any]],
+        partition_columns: Optional[list[str]] = None,
+        editable: Optional[bool] = True,
+    ) -> None:
+        """Create a new table in EimerDB.
+
+        Args:
+            table_name (str): Name of the new table.
+            schema (str): JSON schema for the table.
+            partition_columns (list, optional): List of partition columns.
+            editable (bool, optional): Indicates if the table is editable.
+
+        Raises:
+            PermissionError: If the current user is not an admin.
+        """
+
+    @abstractmethod
+    def insert(self, table_name: str, df: pd.DataFrame) -> None:
+        """Insert unedited data into a main table.
+
+        Args:
+            table_name (str): Name of the table to insert data into.
+            df (pandas.DataFrame): DataFrame containing the data to insert
+
+        Raises:
+            PermissionError: If the current user is not an admin.
+        """
+
+    @abstractmethod
+    def get_changes(self, table_name: str) -> pa.Table:
+        """Retrieve changes for a given table.
+
+        Args:
+            table_name (str): The name of the table for which changes are to be retrieved.
+
+        Returns:
+            Table: A pyarrow table containing the changes for the specified table.
+        """
+
+    @abstractmethod
+    def get_inserts(self, table_name: str, raw: bool) -> pa.Table:
+        """Retrieve changes for a given table.
+
+        Args:
+            table_name (str): The name of the table for which changes are to be retrieved.
+            raw (bool): Indicates whether to retrieve the raw schema.
+
+        Returns:
+            DataFrame: A pandas DataFrame containing the changes for the specified table.
+        """
+
+    @abstractmethod
+    def combine_changes(self, table_name: str) -> None:
+        """Combines the files containing the changes of the table into one file.
+
+        Args:
+            table_name (str): The name of the table for which changes are to be merged.
+        """
+
+    @abstractmethod
+    def combine_inserts(self, table_name: str, raw: bool) -> None:
+        """Combines the files containing the inserts of the table into one file.
+
+        Args:
+            table_name (str): The name of the table.
+            raw (bool): Indicates whether to retrieve the raw schema.
+        """
+
+    @abstractmethod
+    def get_arrow_schema(
+        self,
+        table_name: str,
+        raw: bool,
+    ) -> pa.Schema:
+        """Get the arrow schema for a specified table.
+
+        Args:
+            table_name (str): The name of the table.
+            raw (bool): Indicates whether to retrieve the raw schema.
+
+        Returns:
+            pa.Schema: The arrow schema for the specified table.
+        """
+
+    @abstractmethod
+    def query(
+        self,
+        sql_query: str,
+        partition_select: Optional[dict[str, Any]] = None,
+        unedited: bool = False,
+        output_format: str = PANDAS_OUTPUT_FORMAT,
+    ) -> Union[pd.DataFrame, pa.Table, str]:
+        """Execute an SQL query on an EimerDB table.
+
+        Args:
+            sql_query (str): SQL query to execute.
+            partition_select (dict, optional): Dictionary specifying partition filters.
+            unedited (bool): Indicates whether to include unedited data.
+            output_format (str): Desired output format ('pandas' or 'arrow').
+
+        Returns:
+            pandas.DataFrame, pyarrow.Table, str: The result of the SQL query.
+
+        Raises:
+            ValueError: If the output format is invalid, table is not editable, or invalid query.
+        """

--- a/src/eimerdb/abstract_db_instance.py
+++ b/src/eimerdb/abstract_db_instance.py
@@ -26,7 +26,7 @@ class AbstractDbInstance(ABC):
         time_created: str,
         tables: dict[str, Any],
         users: dict[str, Any],
-        role_groups: dict[str, Any],
+        role_groups: Optional[dict[str, Any]],
         is_admin: bool,
     ) -> None:
         """Initialize AbstractDbInstance.
@@ -40,7 +40,7 @@ class AbstractDbInstance(ABC):
             time_created (str): Time when the EimerDB was created.
             tables (dict): Dictionary containing the tables in the EimerDB.
             users (dict): Dictionary containing the users in the EimerDB.
-            role_groups (dict): Dictionary containing the role groups in the EimerDB.
+            role_groups (dict, optional): Dictionary containing the role groups in the EimerDB.
             is_admin (bool): Indicates whether the current user is an admin.
         """
         self.bucket_name = bucket_name

--- a/src/eimerdb/eimerdb_constants.py
+++ b/src/eimerdb/eimerdb_constants.py
@@ -17,3 +17,12 @@ PARTITION_COLUMNS_KEY = "partition_columns"
 SCHEMA_KEY = "schema"
 
 DUCKDB_DEFAULT_CONFIG = {"preserve_insertion_order": False}
+
+ROW_ID_DEF = {"name": "row_id", "type": "string", "label": "Unique row ID"}
+PANDAS_OUTPUT_FORMAT = "pandas"
+ARROW_OUTPUT_FORMAT = "arrow"
+
+CHANGES_ALL = "all"
+CHANGES_RECENT = "recent"
+
+SELECT_STAR_QUERY = "SELECT * FROM"

--- a/src/eimerdb/instance.py
+++ b/src/eimerdb/instance.py
@@ -16,48 +16,35 @@ from typing import Optional
 from typing import Union
 from uuid import uuid4
 
-import duckdb
 import pandas as pd
 import pyarrow as pa
 import pyarrow.dataset as ds
 import pyarrow.parquet as pq
 from dapla import AuthClient
 from dapla import FileClient
-from gcsfs import GCSFileSystem
 from google.cloud import storage
 from pyarrow import Table
 
+from .abstract_db_instance import AbstractDbInstance
 from .eimerdb_constants import APPLICATION_JSON
+from .eimerdb_constants import ARROW_OUTPUT_FORMAT
 from .eimerdb_constants import BUCKET_KEY
-from .eimerdb_constants import COLUMNS_KEY
 from .eimerdb_constants import CREATED_BY_KEY
-from .eimerdb_constants import DUCKDB_DEFAULT_CONFIG
 from .eimerdb_constants import EDITABLE_KEY
 from .eimerdb_constants import OPERATION_KEY
+from .eimerdb_constants import PANDAS_OUTPUT_FORMAT
 from .eimerdb_constants import PARTITION_COLUMNS_KEY
+from .eimerdb_constants import ROW_ID_DEF
 from .eimerdb_constants import SCHEMA_KEY
-from .eimerdb_constants import TABLE_NAME_KEY
 from .eimerdb_constants import TABLE_PATH_KEY
-from .eimerdb_constants import WHERE_CLAUSE_KEY
 from .functions import arrow_schema_from_json
 from .functions import get_datetime
 from .functions import get_initials
 from .functions import get_json
 from .functions import parse_sql_query
-from .query import filter_partitions
-from .query import get_partitioned_files
-from .query import update_pyarrow_table
+from .instance_query_worker import QueryWorker
 
 logger = logging.getLogger(__name__)
-
-ROW_ID_DEF = {"name": "row_id", "type": "string", "label": "Unique row ID"}
-PANDAS_OUTPUT_FORMAT = "pandas"
-ARROW_OUTPUT_FORMAT = "arrow"
-
-CHANGES_ALL = "all"
-CHANGES_RECENT = "recent"
-
-SELECT_STAR_QUERY = "SELECT * FROM"
 
 
 class DbOperation(str):
@@ -68,7 +55,7 @@ class DbOperation(str):
     DELETE_QUERY_OPERATION = "DELETE"
 
 
-class EimerDBInstance:
+class EimerDBInstance(AbstractDbInstance):
     """Represents an instance of the EimerDB database.
 
     This class provides methods to interact with EimerDB, including
@@ -80,7 +67,7 @@ class EimerDBInstance:
         eimer_name (str): The name of the EimerDB instance.
 
     Attributes:
-        bucket (str): The name of the Google Cloud Storage bucket.
+        bucket_name (str): The name of the Google Cloud Storage bucket.
         eimerdb_name (str): The name of the EimerDB instance.
         path (str): The path to the EimerDB configuration.
         eimer_path (str): The path to the EimerDB instance.
@@ -113,38 +100,37 @@ class EimerDBInstance:
             bucket_name (str): GCS bucket name.
             eimer_name (str): EimerDB instance name.
         """
-        self.bucket = bucket_name
-
         about_path = f"eimerdb/{eimer_name}/config/about.json"
         json_about = get_json(bucket_name, about_path)
 
-        self.eimerdb_name = json_about["eimerdb_name"]
-        self.path = json_about["path"]
-        self.eimer_path = json_about["eimer_path"]
-        self.created_by = json_about[CREATED_BY_KEY]
-        self.time_created = json_about["time_created"]
+        eimer_path = json_about["eimer_path"]
+        users: dict[str, Any] = get_json(bucket_name, f"{eimer_path}/config/users.json")
 
         initials = get_initials()
-
-        users_path = f"{self.eimer_path}/config/users.json"
-        users = get_json(bucket_name, users_path)
-
-        role_groups_path = f"{self.eimer_path}/config/role_groups.json"
-        role_groups = get_json(bucket_name, role_groups_path)
-
-        tables_path = f"{self.eimer_path}/config/tables.json"
-        tables = get_json(bucket_name, tables_path)
-
-        self.tables = tables
-
-        self.users: dict[str, Any] = {initials: ""}
-        self.role_groups: Optional[dict[str, Any]] = None
-        self.is_admin: bool = False
-
         if initials in users and users[initials] == "admin":
-            self.users = users
-            self.role_groups = role_groups
-            self.is_admin = True
+            role_groups: Optional[dict[str, Any]] = get_json(
+                bucket_name, f"{eimer_path}/config/role_groups.json"
+            )
+            is_admin = True
+        else:
+            users = {initials: ""}
+            role_groups: Optional[dict[str, Any]] = None
+            is_admin: bool = False
+
+        super().__init__(
+            bucket_name=bucket_name,
+            eimerdb_name=json_about["eimerdb_name"],
+            path=json_about["path"],
+            eimer_path=eimer_path,
+            created_by=json_about[CREATED_BY_KEY],
+            time_created=json_about["time_created"],
+            tables=get_json(bucket_name, f"{eimer_path}/config/tables.json"),
+            users=users,
+            role_groups=role_groups,
+            is_admin=is_admin,
+        )
+
+        self.query_worker = QueryWorker(self)
 
     def add_user(self, username: str, role: Any) -> None:
         """Add a user with a specified role.
@@ -164,7 +150,7 @@ class EimerDBInstance:
             raise ValueError(f"User {username} already exists!")
 
         client = storage.Client(credentials=AuthClient.fetch_google_credentials())
-        bucket = client.bucket(self.bucket)
+        bucket = client.bucket(self.bucket_name)
 
         self.users.update({username: role})
         user_roles_blob = bucket.blob(f"{self.eimer_path}/config/users.json")
@@ -191,7 +177,7 @@ class EimerDBInstance:
             raise ValueError(f"User {username} does not exist.")
 
         client = storage.Client(credentials=AuthClient.fetch_google_credentials())
-        bucket = client.bucket(self.bucket)
+        bucket = client.bucket(self.bucket_name)
 
         del self.users[username]
         user_roles_blob = bucket.blob(f"{self.eimer_path}/config/users.json")
@@ -227,7 +213,7 @@ class EimerDBInstance:
             table_name: {
                 CREATED_BY_KEY: get_initials(),
                 TABLE_PATH_KEY: f"{self.eimer_path}/{table_name}",
-                BUCKET_KEY: self.bucket,
+                BUCKET_KEY: self.bucket_name,
                 EDITABLE_KEY: editable,
                 SCHEMA_KEY: schema,
                 PARTITION_COLUMNS_KEY: partition_columns,
@@ -236,7 +222,7 @@ class EimerDBInstance:
         self.tables.update(new_table)
 
         token = AuthClient.fetch_google_credentials()
-        bucket = storage.Client(credentials=token).bucket(self.bucket)
+        bucket = storage.Client(credentials=token).bucket(self.bucket_name)
 
         tables_blob = bucket.blob(f"{self.eimer_path}/config/tables.json")
         tables_blob.upload_from_string(
@@ -260,7 +246,7 @@ class EimerDBInstance:
 
         df["row_id"] = df.apply(lambda row: str(uuid4()), axis=1)
 
-        arrow_schema = self._get_arrow_schema(table_name, False)
+        arrow_schema = self.get_arrow_schema(table_name, False)
         table = pa.Table.from_pandas(df, schema=arrow_schema)
 
         df_raw = df.copy()
@@ -269,7 +255,7 @@ class EimerDBInstance:
         df_raw[OPERATION_KEY] = "insert"
 
         table_raw = pa.Table.from_pandas(
-            df_raw, schema=self._get_arrow_schema(table_name, True)
+            df_raw, schema=self.get_arrow_schema(table_name, True)
         )
         timestamp_column = table_raw["datetime"].cast(pa.timestamp("ns"))
 
@@ -292,7 +278,7 @@ class EimerDBInstance:
         # noinspection PyTypeChecker
         pq.write_to_dataset(
             table=table,
-            root_path=f"gs://{self.bucket}/{table_path}",
+            root_path=f"gs://{self.bucket_name}/{table_path}",
             partition_cols=partitions,
             basename_template=filename,
             filesystem=fs,
@@ -301,7 +287,7 @@ class EimerDBInstance:
         # noinspection PyTypeChecker
         pq.write_to_dataset(
             table=table_raw,
-            root_path=f"gs://{self.bucket}/{table_path}_raw",
+            root_path=f"gs://{self.bucket_name}/{table_path}_raw",
             partition_cols=partitions,
             basename_template=filename,
             filesystem=fs,
@@ -322,10 +308,10 @@ class EimerDBInstance:
         fs = FileClient.get_gcs_file_system()
         # noinspection PyTypeChecker
         dataset = ds.dataset(
-            f"{self.bucket}/{path}_changes/",
+            f"{self.bucket_name}/{path}_changes/",
             format="parquet",
             partitioning="hive",
-            schema=self._get_arrow_schema(table_name, True),
+            schema=self.get_arrow_schema(table_name, True),
             filesystem=fs,
         )
 
@@ -352,10 +338,10 @@ class EimerDBInstance:
         fs = FileClient.get_gcs_file_system()
         # noinspection PyTypeChecker
         dataset = ds.dataset(
-            f"{self.bucket}/{path}/",
+            f"{self.bucket_name}/{path}/",
             format="parquet",
             partitioning="hive",
-            schema=self._get_arrow_schema(table_name, raw),
+            schema=self.get_arrow_schema(table_name, raw),
             filesystem=fs,
         )
 
@@ -369,7 +355,7 @@ class EimerDBInstance:
             table_name (str): The name of the table for which changes are to be merged.
         """
         client = storage.Client(credentials=AuthClient.fetch_google_credentials())
-        bucket = client.bucket(self.bucket)
+        bucket = client.bucket(self.bucket_name)
 
         partitions = self.tables[table_name][PARTITION_COLUMNS_KEY]
         source_folder = self.tables[table_name][TABLE_PATH_KEY] + "_changes"
@@ -378,10 +364,10 @@ class EimerDBInstance:
         # noinspection PyTypeChecker
         pq.write_to_dataset(
             table=self.get_changes(table_name),
-            root_path=f"gs://{self.bucket}/{source_folder}",
+            root_path=f"gs://{self.bucket_name}/{source_folder}",
             partition_cols=partitions,
             basename_template=f"merged_commit_{uuid4()}_{{i}}.parquet",
-            schema=self._get_arrow_schema(table_name, True),
+            schema=self.get_arrow_schema(table_name, True),
             filesystem=FileClient.get_gcs_file_system(),
         )
         for blob in blobs_to_delete:
@@ -402,7 +388,7 @@ class EimerDBInstance:
             suffix = ""
 
         client = storage.Client(credentials=AuthClient.fetch_google_credentials())
-        bucket = client.bucket(self.bucket)
+        bucket = client.bucket(self.bucket_name)
 
         partitions = self.tables[table_name][PARTITION_COLUMNS_KEY]
         source_folder = self.tables[table_name][TABLE_PATH_KEY] + suffix
@@ -411,10 +397,10 @@ class EimerDBInstance:
         # noinspection PyTypeChecker
         pq.write_to_dataset(
             table=self.get_inserts(table_name, raw),
-            root_path=f"gs://{self.bucket}/{source_folder}",
+            root_path=f"gs://{self.bucket_name}/{source_folder}",
             partition_cols=partitions,
             basename_template=f"merged_commit_{uuid4()}_{{i}}.parquet",
-            schema=self._get_arrow_schema(table_name, raw),
+            schema=self.get_arrow_schema(table_name, raw),
             filesystem=FileClient.get_gcs_file_system(),
         )
         for blob in blobs_to_delete:
@@ -422,7 +408,7 @@ class EimerDBInstance:
 
         print("The inserts were successfully merged into one file per partition!")
 
-    def _get_arrow_schema(
+    def get_arrow_schema(
         self,
         table_name: str,
         raw: bool,
@@ -445,153 +431,6 @@ class EimerDBInstance:
             arrow_schema = arrow_schema.append(pa.field("operation", pa.string()))
 
         return arrow_schema
-
-    def _query_select(
-        self,
-        fs: GCSFileSystem,
-        parsed_query: dict[str, Any],
-        sql_query: str,
-        partition_select: Optional[dict[str, Any]] = None,
-        unedited: bool = False,
-        output_format: str = PANDAS_OUTPUT_FORMAT,
-    ) -> Union[pd.DataFrame, pa.Table]:
-        con = duckdb.connect(config=DUCKDB_DEFAULT_CONFIG)
-        tables = parsed_query[TABLE_NAME_KEY]
-
-        for table_name in tables:
-            table_config = self.tables[table_name]
-
-            table_files = get_partitioned_files(
-                table_name=table_name,
-                instance_name=self.eimerdb_name,
-                table_config=table_config,
-                suffix="_raw",
-                fs=fs,
-                partition_select=partition_select,
-                unedited=unedited,
-            )
-
-            # noinspection PyTypeChecker
-            df = pq.read_table(table_files, filesystem=fs)
-            df_changes = None
-            editable = table_config[EDITABLE_KEY]
-
-            if editable is True and unedited is False:
-                select_query = SELECT_STAR_QUERY
-                df_changes = self.query_changes(
-                    f"{select_query} {table_name}",
-                    partition_select,
-                    output_format=ARROW_OUTPUT_FORMAT,
-                    changes_output=CHANGES_RECENT,
-                )
-
-            if editable is True and unedited is False and df_changes is not None:
-                if df_changes is not None and df_changes.num_rows != 0:
-                    df = update_pyarrow_table(df, df_changes)
-
-            con.register(table_name, df)
-            del df
-
-        if output_format == PANDAS_OUTPUT_FORMAT:
-            return con.execute(sql_query).df()
-        else:
-            return con.execute(sql_query).arrow()
-
-    def _query_update(
-        self,
-        fs: GCSFileSystem,
-        parsed_query: dict[str, Any],
-        sql_query: str,
-        partition_select: Optional[dict[str, Any]] = None,
-    ) -> str:
-        table_name = parsed_query[TABLE_NAME_KEY]
-        where_clause = parsed_query[WHERE_CLAUSE_KEY]
-
-        table_config = self.tables[table_name]
-        partitions = table_config[PARTITION_COLUMNS_KEY]
-
-        if table_config[EDITABLE_KEY] is not True:
-            raise ValueError(f"The table {table_name} is not editable!")
-
-        df_update_results: pd.DataFrame = self.query(
-            f"{SELECT_STAR_QUERY} {table_name} WHERE {where_clause}",
-            partition_select,
-        )
-
-        df_update_results["user"] = get_initials()
-        df_update_results["datetime"] = get_datetime()
-        df_update_results["operation"] = "update"
-
-        arrow_schema = self._get_arrow_schema(table_name, True)
-
-        dataset = pa.Table.from_pandas(df_update_results, schema=arrow_schema)
-        con = duckdb.connect()
-        con.register("dataset", dataset)
-        con.execute(f"CREATE TABLE updates AS FROM dataset WHERE {where_clause}")
-
-        sql_query = sql_query.replace(f"UPDATE {table_name}", "UPDATE updates")
-        con.execute(sql_query)
-        df_updates_commits = con.table("updates").df()
-
-        table_path = self.tables[table_name][TABLE_PATH_KEY] + "_changes"
-        update_table = pa.Table.from_pandas(df_updates_commits, schema=arrow_schema)
-
-        # noinspection PyTypeChecker
-        pq.write_to_dataset(
-            table=update_table,
-            root_path=f"gs://{self.bucket}/{table_path}",
-            partition_cols=partitions,
-            basename_template=f"commit_{uuid4()}_{{i}}.parquet",
-            schema=self._get_arrow_schema(table_name, True),
-            filesystem=fs,
-        )
-        return f"{df_updates_commits.shape[0]} rows updated by {get_initials()}"
-
-    def _query_delete(
-        self,
-        fs: GCSFileSystem,
-        parsed_query: dict[str, Any],
-        partition_select: Optional[dict[str, Any]] = None,
-    ) -> str:
-        table_name = parsed_query[TABLE_NAME_KEY]
-        where_clause = parsed_query[WHERE_CLAUSE_KEY]
-
-        table_config = self.tables[table_name]
-
-        if table_config[EDITABLE_KEY] is not True:
-            raise ValueError(f"The table {table_name} is not editable!")
-
-        partitions = table_config[PARTITION_COLUMNS_KEY]
-
-        df_delete_results: pd.DataFrame = self.query(
-            sql_query=f"{SELECT_STAR_QUERY} {table_name} WHERE {where_clause}",
-            partition_select=partition_select,
-        )
-
-        df_delete_results["user"] = get_initials()
-        df_delete_results["datetime"] = get_datetime()
-        df_delete_results["operation"] = "delete"
-
-        arrow_schema = self._get_arrow_schema(table_name, True)
-
-        dataset = pa.Table.from_pandas(df_delete_results, schema=arrow_schema)
-        con = duckdb.connect()
-        con.register("dataset", dataset)
-        con.execute(f"CREATE TABLE deletes AS FROM dataset WHERE {where_clause}")
-
-        df_deletions = con.table("deletes").df()
-        table_path = table_config[TABLE_PATH_KEY] + "_changes"
-        deletion_table = pa.Table.from_pandas(df_deletions, schema=arrow_schema)
-
-        # noinspection PyTypeChecker
-        pq.write_to_dataset(
-            table=deletion_table,
-            root_path=f"gs://{self.bucket}/{table_path}",
-            partition_cols=partitions,
-            basename_template=f"commit_{uuid4()}_{{i}}.parquet",
-            filesystem=fs,
-        )
-        return f"{df_deletions.shape[0]} rows deleted by {get_initials()}"
 
     def query(
         self,
@@ -625,7 +464,7 @@ class EimerDBInstance:
 
         match query_operation:
             case DbOperation.SELECT_QUERY_OPERATION:
-                return self._query_select(
+                return self.query_worker.query_select(
                     fs=fs,
                     parsed_query=parsed_query,
                     sql_query=sql_query,
@@ -634,185 +473,17 @@ class EimerDBInstance:
                     output_format=output_format,
                 )
             case DbOperation.UPDATE_QUERY_OPERATION:
-                return self._query_update(
+                return self.query_worker.query_update(
                     fs=fs,
                     parsed_query=parsed_query,
                     sql_query=sql_query,
                     partition_select=partition_select,
                 )
             case DbOperation.DELETE_QUERY_OPERATION:
-                return self._query_delete(
+                return self.query_worker.query_delete(
                     fs=fs,
                     parsed_query=parsed_query,
                     partition_select=partition_select,
                 )
             case _:
                 raise ValueError(f"Unsupported SQL operation: {query_operation}.")
-
-    def query_changes(
-        self,
-        sql_query: str,
-        partition_select: Optional[dict[str, Any]] = None,
-        unedited: bool = False,
-        output_format: str = PANDAS_OUTPUT_FORMAT,
-        changes_output: str = CHANGES_ALL,
-    ) -> Optional[Union[pd.DataFrame, pa.Table]]:
-        """Query changes made in the database table.
-
-        Args:
-            sql_query (str): The SQL query to execute.
-            partition_select (Dict, optional):
-                Dictionary containing partition selection criteria. Defaults to None.
-            unedited (bool):
-                Flag indicating whether to retrieve unedited changes. Defaults to False.
-            output_format (str):
-                The desired output format ('pandas' or 'arrow'). Defaults to 'pandas'.
-            changes_output (str):
-                The changes that are to be retrieved ('recent' or 'all'). Defaults to 'all'.
-
-        Returns:
-            Optional[pd.DataFrame, pa.Table]:
-                Returns a pandas DataFrame if 'pandas' output format is specified,
-                an arrow Table if 'arrow' output format is specified,
-                or None if operation is different from SELECT.
-
-        Raises:
-            ValueError: If the output format is invalid.
-        """
-        if output_format not in (PANDAS_OUTPUT_FORMAT, ARROW_OUTPUT_FORMAT):
-            raise ValueError(f"Invalid output format: {output_format}")
-
-        # Validate changes_output
-        if changes_output not in (CHANGES_ALL, CHANGES_RECENT):
-            raise ValueError(f"Invalid changes output: {changes_output}")
-
-        parsed_query = parse_sql_query(sql_query)
-        # Check if the operation is SELECT
-        if parsed_query[OPERATION_KEY] != "SELECT":
-            raise ValueError(
-                f"Operation {parsed_query[OPERATION_KEY]} is not supported."
-            )
-
-        table_name = parsed_query[TABLE_NAME_KEY][0]
-        table_config = self.tables[table_name]
-
-        def get_partition_levels() -> str:
-            partitions = table_config[PARTITION_COLUMNS_KEY]
-            partitions_len = len(partitions) if partitions is not None else 0
-            return "**/" * partitions_len + "*"
-
-        def get_columns(_local_changes_output: str) -> Optional[list[str]]:
-            if _local_changes_output == CHANGES_RECENT:
-                return None
-
-            columns = parsed_query.get(COLUMNS_KEY)
-            if columns == ["*"]:
-                return None
-
-            return columns
-
-        def get_duckdb_query(_local_changes_output: str) -> str:
-            modified_query = sql_query.replace(f"FROM {table_name}", "FROM dataset")
-
-            if _local_changes_output == CHANGES_RECENT:
-                return modified_query
-
-            if (
-                get_columns(_local_changes_output) is not None
-                and table_config[EDITABLE_KEY] is True
-                and unedited is not True
-            ):
-                # add row_id to the select clause
-                return modified_query.replace(" FROM", ", row_id FROM")
-
-            return modified_query
-
-        fs = FileClient.get_gcs_file_system()
-
-        def get_change_dataset(local_changes_output: str) -> Optional[Table]:
-            changes_suffix = (
-                "changes_all" if local_changes_output == CHANGES_ALL else "changes"
-            )
-
-            changes_files = fs.glob(
-                f"gs://{table_config[BUCKET_KEY]}/eimerdb/{self.eimerdb_name}/{table_name}_{changes_suffix}/"
-                f"{get_partition_levels()}"
-            )
-
-            try:
-                max_depth = max(obj.count("/") for obj in changes_files)
-            except ValueError:
-                return None
-
-            changes_files_max_depth = [
-                obj for obj in changes_files if obj.count("/") == max_depth
-            ]
-
-            if partition_select is not None:
-                changes_files_max_depth = filter_partitions(
-                    table_files=changes_files_max_depth,
-                    partition_select=partition_select,
-                )
-
-            # noinspection PyTypeChecker
-            dataset = pq.read_table(
-                source=changes_files_max_depth,
-                schema=self._get_arrow_schema(table_name, True),
-                filesystem=fs,
-                columns=get_columns(local_changes_output),
-            )
-
-            return dataset if dataset.num_rows > 0 else None
-
-        def get_changes_query_result(
-            local_changes_output: str,
-        ) -> Optional[Union[pd.DataFrame, pa.Table]]:
-            dataset = get_change_dataset(local_changes_output)
-            if dataset is None:
-                return None
-
-            conn = duckdb.connect(config=DUCKDB_DEFAULT_CONFIG)
-            query_result = conn.query(get_duckdb_query(local_changes_output))
-            if output_format == PANDAS_OUTPUT_FORMAT:
-                return query_result.df()
-            else:
-                column_order = [
-                    field.name for field in self._get_arrow_schema(table_name, True)
-                ]
-                return query_result.arrow().select(column_order)
-
-        def cast_if_arrow(
-            table: Optional[Union[pd.DataFrame, pa.Table]]
-        ) -> Optional[Union[pd.DataFrame, pa.Table]]:
-            if table is None or output_format == PANDAS_OUTPUT_FORMAT:
-                return table
-
-            return table.cast(self._get_arrow_schema(table_name, True))
-
-        def concat_changes(
-            first: Optional[Union[pd.DataFrame, pa.Table]],
-            second: Optional[Union[pd.DataFrame, pa.Table]],
-        ) -> Optional[Union[pd.DataFrame, pa.Table]]:
-            if first is None and second is None:
-                return None
-
-            if first is None:
-                return cast_if_arrow(second)
-
-            if second is None:
-                return cast_if_arrow(first)
-
-            if output_format == PANDAS_OUTPUT_FORMAT:
-                return pd.concat([first, second])
-            else:
-                table = pa.concat_tables([first, second])
-                return cast_if_arrow(table)
-
-        # method body
-        if changes_output == CHANGES_ALL:
-            return concat_changes(
-                first=get_changes_query_result(CHANGES_ALL),
-                second=get_changes_query_result(CHANGES_RECENT),
-            )
-        else:
-            return cast_if_arrow(get_changes_query_result(changes_output))

--- a/src/eimerdb/instance.py
+++ b/src/eimerdb/instance.py
@@ -111,11 +111,11 @@ class EimerDBInstance(AbstractDbInstance):
             role_groups: Optional[dict[str, Any]] = get_json(
                 bucket_name, f"{eimer_path}/config/role_groups.json"
             )
-            is_admin = True
+            is_admin: bool = True
         else:
             users = {initials: ""}
-            role_groups: Optional[dict[str, Any]] = None
-            is_admin: bool = False
+            role_groups = None
+            is_admin = False
 
         super().__init__(
             bucket_name=bucket_name,

--- a/src/eimerdb/instance_query_changes_worker.py
+++ b/src/eimerdb/instance_query_changes_worker.py
@@ -1,0 +1,212 @@
+import logging
+from typing import Any
+from typing import Optional
+from typing import Union
+
+import duckdb
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from dapla import FileClient
+from pyarrow import Table
+
+from .abstract_db_instance import AbstractDbInstance
+from .eimerdb_constants import ARROW_OUTPUT_FORMAT
+from .eimerdb_constants import BUCKET_KEY
+from .eimerdb_constants import CHANGES_ALL
+from .eimerdb_constants import CHANGES_RECENT
+from .eimerdb_constants import COLUMNS_KEY
+from .eimerdb_constants import DUCKDB_DEFAULT_CONFIG
+from .eimerdb_constants import EDITABLE_KEY
+from .eimerdb_constants import OPERATION_KEY
+from .eimerdb_constants import PANDAS_OUTPUT_FORMAT
+from .eimerdb_constants import PARTITION_COLUMNS_KEY
+from .eimerdb_constants import TABLE_NAME_KEY
+from .functions import parse_sql_query
+from .query import filter_partitions
+
+logger = logging.getLogger(__name__)
+
+
+class QueryChangesWorker:
+    """Internal class for offloading query_changes.
+
+    Do not create an instance of this class directly.
+    """
+
+    def __init__(self, db_instance: AbstractDbInstance) -> None:
+        """Initialize QueryChangesWorker.
+
+        Args:
+            db_instance: The EimerDBInstance instance.
+        """
+        self.db_instance = db_instance
+
+    def query_changes(
+        self,
+        sql_query: str,
+        partition_select: Optional[dict[str, Any]] = None,
+        unedited: bool = False,
+        output_format: str = PANDAS_OUTPUT_FORMAT,
+        changes_output: str = CHANGES_ALL,
+    ) -> Optional[Union[pd.DataFrame, pa.Table]]:
+        """Query changes made in the database table.
+
+        Args:
+            sql_query (str): The SQL query to execute.
+            partition_select (Dict, optional):
+                Dictionary containing partition selection criteria. Defaults to None.
+            unedited (bool):
+                Flag indicating whether to retrieve unedited changes. Defaults to False.
+            output_format (str):
+                The desired output format ('pandas' or 'arrow'). Defaults to 'pandas'.
+            changes_output (str):
+                The changes that are to be retrieved ('recent' or 'all'). Defaults to 'all'.
+
+        Returns:
+            Optional[pd.DataFrame, pa.Table]:
+                Returns a pandas DataFrame if 'pandas' output format is specified,
+                an arrow Table if 'arrow' output format is specified,
+                or None if operation is different from SELECT.
+
+        Raises:
+            ValueError: If the output format is invalid.
+        """
+        if output_format not in (PANDAS_OUTPUT_FORMAT, ARROW_OUTPUT_FORMAT):
+            raise ValueError(f"Invalid output format: {output_format}")
+
+        # Validate changes_output
+        if changes_output not in (CHANGES_ALL, CHANGES_RECENT):
+            raise ValueError(f"Invalid changes output: {changes_output}")
+
+        parsed_query = parse_sql_query(sql_query)
+        # Check if the operation is SELECT
+        if parsed_query[OPERATION_KEY] != "SELECT":
+            raise ValueError(
+                f"Operation {parsed_query[OPERATION_KEY]} is not supported."
+            )
+
+        table_name = parsed_query[TABLE_NAME_KEY][0]
+        table_config = self.db_instance.tables[table_name]
+
+        def get_partition_levels() -> str:
+            partitions = table_config[PARTITION_COLUMNS_KEY]
+            partitions_len = len(partitions) if partitions is not None else 0
+            return "**/" * partitions_len + "*"
+
+        def get_columns(_local_changes_output: str) -> Optional[list[str]]:
+            if _local_changes_output == CHANGES_RECENT:
+                return None
+
+            columns = parsed_query.get(COLUMNS_KEY)
+            if columns == ["*"]:
+                return None
+
+            return columns
+
+        def get_duckdb_query(_local_changes_output: str) -> str:
+            modified_query = sql_query.replace(f"FROM {table_name}", "FROM dataset")
+
+            if _local_changes_output == CHANGES_RECENT:
+                return modified_query
+
+            if (
+                get_columns(_local_changes_output) is not None
+                and table_config[EDITABLE_KEY] is True
+                and unedited is not True
+            ):
+                # add row_id to the select clause
+                return modified_query.replace(" FROM", ", row_id FROM")
+
+            return modified_query
+
+        fs = FileClient.get_gcs_file_system()
+
+        def get_change_dataset(local_changes_output: str) -> Optional[Table]:
+            changes_suffix = (
+                "changes_all" if local_changes_output == CHANGES_ALL else "changes"
+            )
+
+            changes_files = fs.glob(
+                f"gs://{table_config[BUCKET_KEY]}/eimerdb/{self.db_instance.eimerdb_name}/"
+                f"{table_name}_{changes_suffix}/{get_partition_levels()}"
+            )
+
+            try:
+                max_depth = max(obj.count("/") for obj in changes_files)
+            except ValueError:
+                return None
+
+            changes_files_max_depth = [
+                obj for obj in changes_files if obj.count("/") == max_depth
+            ]
+
+            if partition_select is not None:
+                changes_files_max_depth = filter_partitions(
+                    table_files=changes_files_max_depth,
+                    partition_select=partition_select,
+                )
+
+            # noinspection PyTypeChecker
+            dataset = pq.read_table(
+                source=changes_files_max_depth,
+                schema=self.db_instance.get_arrow_schema(table_name, True),
+                filesystem=fs,
+                columns=get_columns(local_changes_output),
+            )
+
+            return dataset if dataset.num_rows > 0 else None
+
+        def get_changes_query_result(
+            local_changes_output: str,
+        ) -> Optional[Union[pd.DataFrame, pa.Table]]:
+            dataset = get_change_dataset(local_changes_output)
+            if dataset is None:
+                return None
+
+            conn = duckdb.connect(config=DUCKDB_DEFAULT_CONFIG)
+            query_result = conn.query(get_duckdb_query(local_changes_output))
+            if output_format == PANDAS_OUTPUT_FORMAT:
+                return query_result.df()
+            else:
+                column_order = [
+                    field.name
+                    for field in self.db_instance.get_arrow_schema(table_name, True)
+                ]
+                return query_result.arrow().select(column_order)
+
+        def cast_if_arrow(
+            table: Optional[Union[pd.DataFrame, pa.Table]]
+        ) -> Optional[Union[pd.DataFrame, pa.Table]]:
+            if table is None or output_format == PANDAS_OUTPUT_FORMAT:
+                return table
+
+            return table.cast(self.db_instance.get_arrow_schema(table_name, True))
+
+        def concat_changes(
+            first: Optional[Union[pd.DataFrame, pa.Table]],
+            second: Optional[Union[pd.DataFrame, pa.Table]],
+        ) -> Optional[Union[pd.DataFrame, pa.Table]]:
+            if first is None and second is None:
+                return None
+
+            if first is None:
+                return cast_if_arrow(second)
+
+            if second is None:
+                return cast_if_arrow(first)
+
+            if output_format == PANDAS_OUTPUT_FORMAT:
+                return pd.concat([first, second])
+            else:
+                table = pa.concat_tables([first, second])
+                return cast_if_arrow(table)
+
+        # method body
+        if changes_output == CHANGES_ALL:
+            return concat_changes(
+                first=get_changes_query_result(CHANGES_ALL),
+                second=get_changes_query_result(CHANGES_RECENT),
+            )
+        else:
+            return cast_if_arrow(get_changes_query_result(changes_output))

--- a/src/eimerdb/instance_query_changes_worker.py
+++ b/src/eimerdb/instance_query_changes_worker.py
@@ -38,7 +38,7 @@ class QueryChangesWorker:
 
     def query_changes(
         self, sql_query: str, partition_select: Optional[dict[str, Any]] = None
-    ) -> Optional[Union[pd.DataFrame, pa.Table]]:
+    ) -> Optional[pa.Table]:
         """Query changes made in the database table.
 
         Args:
@@ -47,13 +47,11 @@ class QueryChangesWorker:
                 Dictionary containing partition selection criteria. Defaults to None.
 
         Returns:
-            Optional[pd.DataFrame, pa.Table]:
-                Returns a pandas DataFrame if 'pandas' output format is specified,
-                an arrow Table if 'arrow' output format is specified,
-                or None if operation is different from SELECT.
+            Optional[pa.Table]:
+                Returns an arrow Table or None
 
         Raises:
-            ValueError: If the output format is invalid.
+            ValueError: If the operation is not supported.
         """
         parsed_query = parse_sql_query(sql_query)
         # Check if the operation is SELECT

--- a/src/eimerdb/instance_query_changes_worker.py
+++ b/src/eimerdb/instance_query_changes_worker.py
@@ -11,15 +11,9 @@ from dapla import FileClient
 from pyarrow import Table
 
 from .abstract_db_instance import AbstractDbInstance
-from .eimerdb_constants import ARROW_OUTPUT_FORMAT
 from .eimerdb_constants import BUCKET_KEY
-from .eimerdb_constants import CHANGES_ALL
-from .eimerdb_constants import CHANGES_RECENT
-from .eimerdb_constants import COLUMNS_KEY
 from .eimerdb_constants import DUCKDB_DEFAULT_CONFIG
-from .eimerdb_constants import EDITABLE_KEY
 from .eimerdb_constants import OPERATION_KEY
-from .eimerdb_constants import PANDAS_OUTPUT_FORMAT
 from .eimerdb_constants import PARTITION_COLUMNS_KEY
 from .eimerdb_constants import TABLE_NAME_KEY
 from .functions import parse_sql_query
@@ -43,12 +37,7 @@ class QueryChangesWorker:
         self.db_instance = db_instance
 
     def query_changes(
-        self,
-        sql_query: str,
-        partition_select: Optional[dict[str, Any]] = None,
-        unedited: bool = False,
-        output_format: str = PANDAS_OUTPUT_FORMAT,
-        changes_output: str = CHANGES_ALL,
+        self, sql_query: str, partition_select: Optional[dict[str, Any]] = None
     ) -> Optional[Union[pd.DataFrame, pa.Table]]:
         """Query changes made in the database table.
 
@@ -56,12 +45,6 @@ class QueryChangesWorker:
             sql_query (str): The SQL query to execute.
             partition_select (Dict, optional):
                 Dictionary containing partition selection criteria. Defaults to None.
-            unedited (bool):
-                Flag indicating whether to retrieve unedited changes. Defaults to False.
-            output_format (str):
-                The desired output format ('pandas' or 'arrow'). Defaults to 'pandas'.
-            changes_output (str):
-                The changes that are to be retrieved ('recent' or 'all'). Defaults to 'all'.
 
         Returns:
             Optional[pd.DataFrame, pa.Table]:
@@ -72,13 +55,6 @@ class QueryChangesWorker:
         Raises:
             ValueError: If the output format is invalid.
         """
-        if output_format not in (PANDAS_OUTPUT_FORMAT, ARROW_OUTPUT_FORMAT):
-            raise ValueError(f"Invalid output format: {output_format}")
-
-        # Validate changes_output
-        if changes_output not in (CHANGES_ALL, CHANGES_RECENT):
-            raise ValueError(f"Invalid changes output: {changes_output}")
-
         parsed_query = parse_sql_query(sql_query)
         # Check if the operation is SELECT
         if parsed_query[OPERATION_KEY] != "SELECT":
@@ -94,42 +70,15 @@ class QueryChangesWorker:
             partitions_len = len(partitions) if partitions is not None else 0
             return "**/" * partitions_len + "*"
 
-        def get_columns(_local_changes_output: str) -> Optional[list[str]]:
-            if _local_changes_output == CHANGES_RECENT:
-                return None
-
-            columns = parsed_query.get(COLUMNS_KEY)
-            if columns == ["*"]:
-                return None
-
-            return columns
-
-        def get_duckdb_query(_local_changes_output: str) -> str:
-            modified_query = sql_query.replace(f"FROM {table_name}", "FROM dataset")
-
-            if _local_changes_output == CHANGES_RECENT:
-                return modified_query
-
-            if (
-                get_columns(_local_changes_output) is not None
-                and table_config[EDITABLE_KEY] is True
-                and unedited is not True
-            ):
-                # add row_id to the select clause
-                return modified_query.replace(" FROM", ", row_id FROM")
-
-            return modified_query
+        def get_duckdb_query() -> str:
+            return sql_query.replace(f"FROM {table_name}", "FROM dataset")
 
         fs = FileClient.get_gcs_file_system()
 
-        def get_change_dataset(local_changes_output: str) -> Optional[Table]:
-            changes_suffix = (
-                "changes_all" if local_changes_output == CHANGES_ALL else "changes"
-            )
-
+        def get_change_dataset() -> Optional[Table]:
             changes_files = fs.glob(
                 f"gs://{table_config[BUCKET_KEY]}/eimerdb/{self.db_instance.eimerdb_name}/"
-                f"{table_name}_{changes_suffix}/{get_partition_levels()}"
+                f"{table_name}_changes/{get_partition_levels()}"
             )
 
             try:
@@ -152,61 +101,32 @@ class QueryChangesWorker:
                 source=changes_files_max_depth,
                 schema=self.db_instance.get_arrow_schema(table_name, True),
                 filesystem=fs,
-                columns=get_columns(local_changes_output),
+                columns=None,
             )
 
             return dataset if dataset.num_rows > 0 else None
 
-        def get_changes_query_result(
-            local_changes_output: str,
-        ) -> Optional[Union[pd.DataFrame, pa.Table]]:
-            dataset = get_change_dataset(local_changes_output)
+        def get_changes_query_result() -> Optional[Union[pd.DataFrame, pa.Table]]:
+            dataset = get_change_dataset()
             if dataset is None:
                 return None
 
             conn = duckdb.connect(config=DUCKDB_DEFAULT_CONFIG)
-            query_result = conn.query(get_duckdb_query(local_changes_output))
-            if output_format == PANDAS_OUTPUT_FORMAT:
-                return query_result.df()
-            else:
-                column_order = [
-                    field.name
-                    for field in self.db_instance.get_arrow_schema(table_name, True)
-                ]
-                return query_result.arrow().select(column_order)
+            query_result = conn.query(get_duckdb_query())
+            column_order = [
+                field.name
+                for field in self.db_instance.get_arrow_schema(table_name, True)
+            ]
+            return query_result.arrow().select(column_order)
 
-        def cast_if_arrow(
+        def cast_arrow(
             table: Optional[Union[pd.DataFrame, pa.Table]]
         ) -> Optional[Union[pd.DataFrame, pa.Table]]:
-            if table is None or output_format == PANDAS_OUTPUT_FORMAT:
-                return table
-
-            return table.cast(self.db_instance.get_arrow_schema(table_name, True))
-
-        def concat_changes(
-            first: Optional[Union[pd.DataFrame, pa.Table]],
-            second: Optional[Union[pd.DataFrame, pa.Table]],
-        ) -> Optional[Union[pd.DataFrame, pa.Table]]:
-            if first is None and second is None:
-                return None
-
-            if first is None:
-                return cast_if_arrow(second)
-
-            if second is None:
-                return cast_if_arrow(first)
-
-            if output_format == PANDAS_OUTPUT_FORMAT:
-                return pd.concat([first, second])
-            else:
-                table = pa.concat_tables([first, second])
-                return cast_if_arrow(table)
+            return (
+                table.cast(self.db_instance.get_arrow_schema(table_name, True))
+                if table is not None
+                else None
+            )
 
         # method body
-        if changes_output == CHANGES_ALL:
-            return concat_changes(
-                first=get_changes_query_result(CHANGES_ALL),
-                second=get_changes_query_result(CHANGES_RECENT),
-            )
-        else:
-            return cast_if_arrow(get_changes_query_result(changes_output))
+        return cast_arrow(get_changes_query_result())

--- a/src/eimerdb/instance_query_worker.py
+++ b/src/eimerdb/instance_query_worker.py
@@ -11,8 +11,6 @@ import pyarrow.parquet as pq
 from gcsfs import GCSFileSystem
 
 from .abstract_db_instance import AbstractDbInstance
-from .eimerdb_constants import ARROW_OUTPUT_FORMAT
-from .eimerdb_constants import CHANGES_RECENT
 from .eimerdb_constants import DUCKDB_DEFAULT_CONFIG
 from .eimerdb_constants import EDITABLE_KEY
 from .eimerdb_constants import PANDAS_OUTPUT_FORMAT
@@ -92,10 +90,7 @@ class QueryWorker:
             if editable is True and unedited is False:
                 select_query = SELECT_STAR_QUERY
                 df_changes = self.query_changes_worker.query_changes(
-                    f"{select_query} {table_name}",
-                    partition_select,
-                    output_format=ARROW_OUTPUT_FORMAT,
-                    changes_output=CHANGES_RECENT,
+                    f"{select_query} {table_name}", partition_select
                 )
 
             if editable is True and unedited is False and df_changes is not None:

--- a/src/eimerdb/instance_query_worker.py
+++ b/src/eimerdb/instance_query_worker.py
@@ -1,0 +1,240 @@
+import logging
+from typing import Any
+from typing import Optional
+from typing import Union
+from uuid import uuid4
+
+import duckdb
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from gcsfs import GCSFileSystem
+
+from .abstract_db_instance import AbstractDbInstance
+from .eimerdb_constants import ARROW_OUTPUT_FORMAT
+from .eimerdb_constants import CHANGES_RECENT
+from .eimerdb_constants import DUCKDB_DEFAULT_CONFIG
+from .eimerdb_constants import EDITABLE_KEY
+from .eimerdb_constants import PANDAS_OUTPUT_FORMAT
+from .eimerdb_constants import PARTITION_COLUMNS_KEY
+from .eimerdb_constants import SELECT_STAR_QUERY
+from .eimerdb_constants import TABLE_NAME_KEY
+from .eimerdb_constants import TABLE_PATH_KEY
+from .eimerdb_constants import WHERE_CLAUSE_KEY
+from .functions import get_datetime
+from .functions import get_initials
+from .functions import parse_sql_query
+from .instance_query_changes_worker import QueryChangesWorker
+from .query import get_partitioned_files
+from .query import update_pyarrow_table
+
+logger = logging.getLogger(__name__)
+
+
+class QueryWorker:
+    """Internal class for offloading query.
+
+    Do not create an instance of this class directly.
+    """
+
+    def __init__(self, db_instance: AbstractDbInstance) -> None:
+        """Initialize QueryWorker.
+
+        Args:
+            db_instance: The AbstractDbInstance instance.
+        """
+        self.db_instance = db_instance
+        self.query_changes_worker = QueryChangesWorker(db_instance)
+
+    def query_select(
+        self,
+        fs: GCSFileSystem,
+        parsed_query: dict[str, Any],
+        sql_query: str,
+        partition_select: Optional[dict[str, Any]] = None,
+        unedited: bool = False,
+        output_format: str = PANDAS_OUTPUT_FORMAT,
+    ) -> Union[pd.DataFrame, pa.Table]:
+        """Query the database.
+
+        Args:
+            fs (GCSFileSystem): The GCSFileSystem instance.
+            parsed_query (dict): The parsed query.
+            sql_query (str): The SQL query to execute.
+            partition_select (dict, optional): Dictionary containing partition selection criteria. Defaults to None.
+            unedited (bool): Flag indicating whether to retrieve unedited data. Defaults to False.
+            output_format (str): Desired output format ('pandas' or 'arrow'). Defaults to PANDAS_OUTPUT_FORMAT.
+
+        Returns:
+            Union[pd.DataFrame, pa.Table]: Returns a pandas DataFrame if 'pandas' output format is specified,
+        """
+        con = duckdb.connect(config=DUCKDB_DEFAULT_CONFIG)
+        tables = parsed_query[TABLE_NAME_KEY]
+
+        for table_name in tables:
+            table_config = self.db_instance.tables[table_name]
+
+            table_files = get_partitioned_files(
+                table_name=table_name,
+                instance_name=self.db_instance.eimerdb_name,
+                table_config=table_config,
+                suffix="_raw",
+                fs=fs,
+                partition_select=partition_select,
+                unedited=unedited,
+            )
+
+            # noinspection PyTypeChecker
+            df = pq.read_table(table_files, filesystem=fs)
+            df_changes = None
+            editable = table_config[EDITABLE_KEY]
+
+            if editable is True and unedited is False:
+                select_query = SELECT_STAR_QUERY
+                df_changes = self.query_changes_worker.query_changes(
+                    f"{select_query} {table_name}",
+                    partition_select,
+                    output_format=ARROW_OUTPUT_FORMAT,
+                    changes_output=CHANGES_RECENT,
+                )
+
+            if editable is True and unedited is False and df_changes is not None:
+                if df_changes is not None and df_changes.num_rows != 0:
+                    df = update_pyarrow_table(df, df_changes)
+
+            con.register(table_name, df)
+            del df
+
+        if output_format == PANDAS_OUTPUT_FORMAT:
+            return con.execute(sql_query).df()
+        else:
+            return con.execute(sql_query).arrow()
+
+    def query_update(
+        self,
+        fs: GCSFileSystem,
+        parsed_query: dict[str, Any],
+        sql_query: str,
+        partition_select: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Query the database to update records.
+
+        Args:
+            fs (GCSFileSystem): The GCSFileSystem instance.
+            parsed_query (dict): The parsed query.
+            sql_query (str): The SQL query to execute.
+            partition_select (Dict, optional): Dictionary containing partition selection criteria. Defaults to None.
+
+        Returns:
+            str: String containing number of rows updated.
+
+        Raises:
+            ValueError: If the table is not editable.
+        """
+        table_name = parsed_query[TABLE_NAME_KEY]
+        where_clause = parsed_query[WHERE_CLAUSE_KEY]
+
+        table_config = self.db_instance.tables[table_name]
+        partitions = table_config[PARTITION_COLUMNS_KEY]
+
+        if table_config[EDITABLE_KEY] is not True:
+            raise ValueError(f"The table {table_name} is not editable!")
+
+        select_query = f"{SELECT_STAR_QUERY} {table_name} WHERE {where_clause}"
+        df_update_results: pd.DataFrame = self.query_select(
+            fs=fs,
+            parsed_query=parse_sql_query(select_query),
+            sql_query=select_query,
+            partition_select=partition_select,
+        )
+
+        df_update_results["user"] = get_initials()
+        df_update_results["datetime"] = get_datetime()
+        df_update_results["operation"] = "update"
+
+        arrow_schema = self.db_instance.get_arrow_schema(table_name, True)
+
+        dataset = pa.Table.from_pandas(df_update_results, schema=arrow_schema)
+        con = duckdb.connect()
+        con.register("dataset", dataset)
+        con.execute(f"CREATE TABLE updates AS FROM dataset WHERE {where_clause}")
+
+        sql_query = sql_query.replace(f"UPDATE {table_name}", "UPDATE updates")
+        con.execute(sql_query)
+        df_updates_commits = con.table("updates").df()
+
+        table_path = self.db_instance.tables[table_name][TABLE_PATH_KEY] + "_changes"
+        update_table = pa.Table.from_pandas(df_updates_commits, schema=arrow_schema)
+
+        # noinspection PyTypeChecker
+        pq.write_to_dataset(
+            table=update_table,
+            root_path=f"gs://{self.db_instance.bucket_name}/{table_path}",
+            partition_cols=partitions,
+            basename_template=f"commit_{uuid4()}_{{i}}.parquet",
+            schema=self.db_instance.get_arrow_schema(table_name, True),
+            filesystem=fs,
+        )
+        return f"{df_updates_commits.shape[0]} rows updated by {get_initials()}"
+
+    def query_delete(
+        self,
+        fs: GCSFileSystem,
+        parsed_query: dict[str, Any],
+        partition_select: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Query the database to delete records.
+
+        Args:
+            fs (GCSFileSystem): The GCSFileSystem instance.
+            parsed_query (dict): The parsed query.
+            partition_select (dict, optional): Dictionary containing partition selection criteria. Defaults to None.
+
+        Returns:
+            str: String containing number of rows deleted.
+
+        Raises:
+            ValueError: If the table is not editable.
+        """
+        table_name = parsed_query[TABLE_NAME_KEY]
+        where_clause = parsed_query[WHERE_CLAUSE_KEY]
+
+        table_config = self.db_instance.tables[table_name]
+
+        if table_config[EDITABLE_KEY] is not True:
+            raise ValueError(f"The table {table_name} is not editable!")
+
+        partitions = table_config[PARTITION_COLUMNS_KEY]
+
+        select_query = f"{SELECT_STAR_QUERY} {table_name} WHERE {where_clause}"
+        df_delete_results: pd.DataFrame = self.query_select(
+            fs=fs,
+            parsed_query=parse_sql_query(select_query),
+            sql_query=select_query,
+            partition_select=partition_select,
+        )
+
+        df_delete_results["user"] = get_initials()
+        df_delete_results["datetime"] = get_datetime()
+        df_delete_results["operation"] = "delete"
+
+        arrow_schema = self.db_instance.get_arrow_schema(table_name, True)
+
+        dataset = pa.Table.from_pandas(df_delete_results, schema=arrow_schema)
+        con = duckdb.connect()
+        con.register("dataset", dataset)
+        con.execute(f"CREATE TABLE deletes AS FROM dataset WHERE {where_clause}")
+
+        df_deletions = con.table("deletes").df()
+        table_path = table_config[TABLE_PATH_KEY] + "_changes"
+        deletion_table = pa.Table.from_pandas(df_deletions, schema=arrow_schema)
+
+        # noinspection PyTypeChecker
+        pq.write_to_dataset(
+            table=deletion_table,
+            root_path=f"gs://{self.db_instance.bucket_name}/{table_path}",
+            partition_cols=partitions,
+            basename_template=f"commit_{uuid4()}_{{i}}.parquet",
+            filesystem=fs,
+        )
+        return f"{df_deletions.shape[0]} rows deleted by {get_initials()}"

--- a/tests/test_instance_admin_user.py
+++ b/tests/test_instance_admin_user.py
@@ -84,7 +84,7 @@ class TestEimerDBInstanceAdminUser(TestEimerDBInstanceBase):
             "test_bucket/path/to/eimer/table1_changes/",
             format="parquet",
             partitioning="hive",
-            schema=self.instance._get_arrow_schema("table1", True),
+            schema=self.instance.get_arrow_schema("table1", True),
             filesystem=ANY,
         )
 
@@ -144,7 +144,7 @@ class TestEimerDBInstanceAdminUser(TestEimerDBInstanceBase):
             f"test_bucket/path/to/eimer/table1{suffix}/",
             format="parquet",
             partitioning="hive",
-            schema=self.instance._get_arrow_schema("table1", raw),
+            schema=self.instance.get_arrow_schema("table1", raw),
             filesystem=ANY,
         )
 
@@ -215,7 +215,7 @@ class TestEimerDBInstanceAdminUser(TestEimerDBInstanceBase):
             root_path="gs://test_bucket/path/to/eimer/table1_changes",
             partition_cols=None,
             basename_template="merged_commit_mocked_uuid_{i}.parquet",
-            schema=self.instance._get_arrow_schema("table1", True),
+            schema=self.instance.get_arrow_schema("table1", True),
             filesystem=ANY,
         )
         blob_1.delete.assert_called_once()
@@ -297,7 +297,7 @@ class TestEimerDBInstanceAdminUser(TestEimerDBInstanceBase):
             root_path=ANY,  # FIXME f"gs://test_bucket/path/to/eimer/table1{suffix}",
             partition_cols=None,
             basename_template="merged_commit_mocked_uuid_{i}.parquet",
-            schema=self.instance._get_arrow_schema("table1", raw),
+            schema=self.instance.get_arrow_schema("table1", raw),
             filesystem=ANY,
         )
 

--- a/tests/test_instance_base.py
+++ b/tests/test_instance_base.py
@@ -1,48 +1,56 @@
 import unittest
-from unittest.mock import Mock
 from unittest.mock import patch
 
 from eimerdb.instance import EimerDBInstance
 
 
 class TestEimerDBInstanceBase(unittest.TestCase):
-    @patch("eimerdb.instance.get_initials", return_value="admin_user")
-    @patch("eimerdb.instance.get_json")
-    def setUp(self, mock_get_json: Mock, _: Mock) -> None:
-        mock_get_json.side_effect = [
-            {
-                "eimerdb_name": "test_eimerdb",
-                "path": "path/to/config",
-                "eimer_path": "path/to/eimer",
-                "created_by": "admin_user",
-                "time_created": "2024-03-09T12:00:00Z",
-            },
-            {"admin_user": "admin"},
-            {"admin_user": {"admin_group": ["admin_user"]}},
-            {
-                "table1": {
-                    "bucket": "test_bucket",
+    def setUp(self) -> None:
+        with patch("eimerdb.instance.get_initials", return_value="admin_user"), patch(
+            "eimerdb.instance.get_json"
+        ) as mock_get_json:
+            mock_get_json.side_effect = [
+                {
+                    "eimerdb_name": "test_eimerdb",
+                    "path": "path/to/config",
+                    "eimer_path": "path/to/eimer",
                     "created_by": "admin_user",
-                    "editable": True,
-                    "partition_columns": None,
-                    "schema": [
-                        {"label": "Unique row ID", "name": "row_id", "type": "string"},
-                        {"label": "Field 1", "name": "field1", "type": "int8"},
-                    ],
-                    "table_path": "path/to/eimer/table1",
+                    "time_created": "2024-03-09T12:00:00Z",
                 },
-                "table2": {
-                    "bucket": "test_bucket",
-                    "created_by": "admin_user",
-                    "editable": False,
-                    "partition_columns": None,
-                    "schema": [
-                        {"label": "Unique row ID", "name": "row_id", "type": "string"},
-                        {"label": "Field 1", "name": "field1", "type": "int8"},
-                    ],
-                    "table_path": "path/to/eimer/table2",
+                {"admin_user": "admin"},
+                {"admin_user": {"admin_group": ["admin_user"]}},
+                {
+                    "table1": {
+                        "bucket": "test_bucket",
+                        "created_by": "admin_user",
+                        "editable": True,
+                        "partition_columns": None,
+                        "schema": [
+                            {
+                                "label": "Unique row ID",
+                                "name": "row_id",
+                                "type": "string",
+                            },
+                            {"label": "Field 1", "name": "field1", "type": "int8"},
+                        ],
+                        "table_path": "path/to/eimer/table1",
+                    },
+                    "table2": {
+                        "bucket": "test_bucket",
+                        "created_by": "admin_user",
+                        "editable": False,
+                        "partition_columns": None,
+                        "schema": [
+                            {
+                                "label": "Unique row ID",
+                                "name": "row_id",
+                                "type": "string",
+                            },
+                            {"label": "Field 1", "name": "field1", "type": "int8"},
+                        ],
+                        "table_path": "path/to/eimer/table2",
+                    },
                 },
-            },
-        ]
+            ]
 
-        self.instance = EimerDBInstance("test_bucket", "test_eimer")
+            self.instance = EimerDBInstance("test_bucket", "test_eimer")

--- a/tests/test_instance_db_manage.py
+++ b/tests/test_instance_db_manage.py
@@ -8,7 +8,7 @@ class TestEimerDBInstanceDbManage(TestEimerDBInstanceBase):
 
     # verify that instance is set up correctly
     def test_init_admin(self) -> None:
-        self.assertEqual(self.instance.bucket, "test_bucket")
+        self.assertEqual(self.instance.bucket_name, "test_bucket")
         self.assertEqual(self.instance.eimerdb_name, "test_eimerdb")
         self.assertEqual(self.instance.path, "path/to/config")
         self.assertEqual(self.instance.eimer_path, "path/to/eimer")

--- a/tests/test_instance_query.py
+++ b/tests/test_instance_query.py
@@ -1,5 +1,3 @@
-from unittest.mock import ANY
-from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -9,168 +7,6 @@ from tests.test_instance_base import TestEimerDBInstanceBase
 
 
 class TestEimerDBInstanceQuery(TestEimerDBInstanceBase):
-
-    #
-    # START _query_select
-    #
-
-    @patch("eimerdb.instance.FileClient.get_gcs_file_system")
-    @patch("eimerdb.instance.get_partitioned_files")
-    @patch("eimerdb.instance.pq.read_table")
-    def test__query_select(
-        self,
-        mock_pq_read_table: Mock,
-        mock_get_partitioned_files: Mock,
-        mock_gcs_filesystem: Mock,
-    ) -> None:
-        # Mock input parameters
-        parsed_query = {"table_name": ["table1"]}
-        sql_query = "SELECT * FROM table1"
-        fs_mock = mock_gcs_filesystem.return_value
-        partition_select = None
-        unedited = False
-        output_format = "pandas"
-
-        # Mock return values
-        mock_pq_read_table.return_value = pd.DataFrame({"row_id": [1, 2, 3]})
-
-        # Call the method
-        result = self.instance._query_select(
-            fs=fs_mock,
-            parsed_query=parsed_query,
-            sql_query=sql_query,
-            partition_select=partition_select,
-            unedited=unedited,
-            output_format=output_format,
-        )
-
-        assert result.equals(pd.DataFrame({"row_id": [1, 2, 3]}))
-
-        mock_get_partitioned_files.assert_called_once_with(
-            table_name="table1",
-            instance_name="test_eimerdb",
-            table_config=self.instance.tables["table1"],
-            suffix="_raw",
-            fs=fs_mock,
-            partition_select=partition_select,
-            unedited=unedited,
-        )
-        mock_pq_read_table.assert_called_once()
-
-    #
-    # START _query_update
-    #
-
-    def test__query_update_non_editable_table(self) -> None:
-        parsed_query = {
-            "operation": "UPDATE",
-            "set_clause": "field1=1",
-            "table_name": "table2",
-            "where_clause": "row_id='1'",
-        }
-
-        # Test & Assertion
-        with self.assertRaises(ValueError) as context:
-            self.instance._query_update(
-                MagicMock(), parsed_query, "UPDATE table2 SET field1='1' WHERE row_id=1"
-            )
-        self.assertEqual(
-            "The table table2 is not editable!",
-            str(context.exception),
-        )
-
-    @patch("eimerdb.instance.EimerDBInstance.query")
-    @patch("eimerdb.instance.pq.write_to_dataset")
-    @patch("eimerdb.instance.uuid4")
-    def test__query_update_success(
-        self, mock_uuid4: Mock, mock_write_to_dataset: Mock, mock_query_method: Mock
-    ) -> None:
-        # Setup mocks
-        mock_uuid4.return_value = "mocked_uuid"
-
-        mock_query_method.return_value = pd.DataFrame(
-            {"field1": [1, 2, 3], "row_id": ["1", "2", "3"]}
-        )
-
-        parsed_query = {
-            "operation": "UPDATE",
-            "set_clause": "field1=1",
-            "table_name": "table1",
-            "where_clause": "row_id='1'",
-        }
-
-        # Call the method
-        result = self.instance._query_update(
-            MagicMock(), parsed_query, "UPDATE table1 SET field1=4 WHERE row_id='1'"
-        )
-
-        # Assertions
-        self.assertEqual("1 rows updated by user", result)
-
-        mock_write_to_dataset.assert_called_with(
-            table=ANY,
-            root_path="gs://test_bucket/path/to/eimer/table1_changes",
-            partition_cols=None,
-            basename_template="commit_mocked_uuid_{i}.parquet",
-            schema=self.instance._get_arrow_schema("table1", True),
-            filesystem=ANY,
-        )
-
-    #
-    # START _query_delete
-    #
-
-    def test__query_delete_non_editable_table(self) -> None:
-        parsed_query = {
-            "operation": "DELETE",
-            "table_name": "table2",
-            "where_clause": "row_id='1'",
-        }
-
-        # Test & Assertion
-        with self.assertRaises(ValueError) as context:
-            self.instance._query_delete(fs=MagicMock(), parsed_query=parsed_query)
-        self.assertEqual(
-            "The table table2 is not editable!",
-            str(context.exception),
-        )
-
-    @patch("eimerdb.instance.EimerDBInstance.query")
-    @patch("eimerdb.instance.pq.write_to_dataset")
-    @patch("eimerdb.instance.uuid4")
-    def test__query_delete_success(
-        self, mock_uuid4: Mock, mock_write_to_dataset: Mock, mock_query_method: Mock
-    ) -> None:
-        # Setup mocks
-        mock_uuid4.return_value = "mocked_uuid"
-
-        mock_query_method.return_value = pd.DataFrame(
-            {"field1": [1, 2, 3], "row_id": ["1", "2", "3"]}
-        )
-
-        parsed_query = {
-            "operation": "DELETE",
-            "table_name": "table1",
-            "where_clause": "row_id='1'",
-        }
-
-        # Call the method
-        result = self.instance._query_delete(fs=MagicMock(), parsed_query=parsed_query)
-
-        # Assertions
-        self.assertEqual("1 rows deleted by user", result)
-
-        mock_write_to_dataset.assert_called_with(
-            table=ANY,
-            root_path="gs://test_bucket/path/to/eimer/table1_changes",
-            partition_cols=None,
-            basename_template="commit_mocked_uuid_{i}.parquet",
-            filesystem=ANY,
-        )
-
-    #
-    # START query
-    #
 
     def test_query_invalid_output_format_expect_exception(self) -> None:
         with self.assertRaises(ValueError) as context:
@@ -198,8 +34,8 @@ class TestEimerDBInstanceQuery(TestEimerDBInstanceBase):
         )
 
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
-    @patch("eimerdb.instance.EimerDBInstance._query_select")
-    def test_query_select(self, mock_query_select: Mock, _: Mock) -> None:
+    @patch("eimerdb.instance_query_worker.QueryWorker.query_select")
+    def test_query_select_expect_result(self, mock_query_select: Mock, _: Mock) -> None:
         mock_query_select.return_value = pd.DataFrame({"row_id": [1, 2, 3]})
 
         self.instance.query("SELECT * FROM table1")
@@ -207,8 +43,8 @@ class TestEimerDBInstanceQuery(TestEimerDBInstanceBase):
         mock_query_select.assert_called_once()
 
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
-    @patch("eimerdb.instance.EimerDBInstance._query_update")
-    def test_query_update(self, mock_query_update: Mock, _: Mock) -> None:
+    @patch("eimerdb.instance_query_worker.QueryWorker.query_update")
+    def test_query_update_expect_result(self, mock_query_update: Mock, _: Mock) -> None:
         mock_query_update.return_value = "1 rows updated by user"
 
         result = self.instance.query(
@@ -219,8 +55,8 @@ class TestEimerDBInstanceQuery(TestEimerDBInstanceBase):
         mock_query_update.assert_called_once()
 
     @patch("eimerdb.instance.FileClient.get_gcs_file_system")
-    @patch("eimerdb.instance.EimerDBInstance._query_delete")
-    def test_query_delete(self, mock_query_delete: Mock, _: Mock) -> None:
+    @patch("eimerdb.instance_query_worker.QueryWorker.query_delete")
+    def test_query_delete_expect_result(self, mock_query_delete: Mock, _: Mock) -> None:
         mock_query_delete.return_value = "1 rows deleted by user"
 
         result = self.instance.query("DELETE FROM table1 WHERE col='value'")

--- a/tests/test_query_changes_worker.py
+++ b/tests/test_query_changes_worker.py
@@ -6,17 +6,25 @@ import pandas as pd
 import pyarrow as pa
 from parameterized import parameterized
 
+from eimerdb.instance_query_changes_worker import QueryChangesWorker
 from tests.test_instance_base import TestEimerDBInstanceBase
 
 
-class TestEimerDBInstanceQueryChanges(TestEimerDBInstanceBase):
+class TestQueryChangesWorker(TestEimerDBInstanceBase):
+
+    worker_instance: QueryChangesWorker
+
     VALID_STAR_QUERY = "SELECT * FROM table1 WHERE row_id='1'"
     VALID_SELECT_QUERY = "SELECT field1 FROM table1 WHERE row_id='1'"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.worker_instance = QueryChangesWorker(self.instance)
 
     def test_query_changes_invalid_output_format_expect_exception(self):
         # Test & Assertion
         with self.assertRaises(ValueError) as context:
-            self.instance.query_changes(
+            self.worker_instance.query_changes(
                 sql_query=self.VALID_STAR_QUERY, output_format="invalid"
             )
         self.assertEqual("Invalid output format: invalid", str(context.exception))
@@ -24,7 +32,7 @@ class TestEimerDBInstanceQueryChanges(TestEimerDBInstanceBase):
     def test_query_changes_invalid_changes_output_expect_exception(self):
         # Test & Assertion
         with self.assertRaises(ValueError) as context:
-            self.instance.query_changes(
+            self.worker_instance.query_changes(
                 sql_query=self.VALID_STAR_QUERY, changes_output="invalid"
             )
         self.assertEqual("Invalid changes output: invalid", str(context.exception))
@@ -32,7 +40,7 @@ class TestEimerDBInstanceQueryChanges(TestEimerDBInstanceBase):
     def test_query_changes_sql_with_update_expect_exception(self):
         # Test & Assertion
         with self.assertRaises(ValueError) as context:
-            self.instance.query_changes(
+            self.worker_instance.query_changes(
                 sql_query="UPDATE table1 SET col1=2 WHERE row_id='1'",
             )
         self.assertEqual("Operation UPDATE is not supported.", str(context.exception))
@@ -91,12 +99,16 @@ class TestEimerDBInstanceQueryChanges(TestEimerDBInstanceBase):
 
         # Patching methods with mocks
         with patch(
-            "eimerdb.instance.FileClient.get_gcs_file_system", return_value=mock_fs
-        ), patch("eimerdb.instance.pq.read_table", return_value=mock_table_data), patch(
-            "eimerdb.instance.duckdb.DuckDBPyConnection.query",
+            "eimerdb.instance_query_changes_worker.FileClient.get_gcs_file_system",
+            return_value=mock_fs,
+        ), patch(
+            "eimerdb.instance_query_changes_worker.pq.read_table",
+            return_value=mock_table_data,
+        ), patch(
+            "eimerdb.instance_query_changes_worker.duckdb.DuckDBPyConnection.query",
             return_value=mock_duckdb_query_result,
         ):
-            result: Union[pd.DataFrame, pa.Table] = self.instance.query_changes(
+            result: Union[pd.DataFrame, pa.Table] = self.worker_instance.query_changes(
                 sql_query=sql_query,
                 unedited=unedited,
                 output_format=output_format,

--- a/tests/test_query_changes_worker.py
+++ b/tests/test_query_changes_worker.py
@@ -21,22 +21,6 @@ class TestQueryChangesWorker(TestEimerDBInstanceBase):
         super().setUp()
         self.worker_instance = QueryChangesWorker(self.instance)
 
-    def test_query_changes_invalid_output_format_expect_exception(self):
-        # Test & Assertion
-        with self.assertRaises(ValueError) as context:
-            self.worker_instance.query_changes(
-                sql_query=self.VALID_STAR_QUERY, output_format="invalid"
-            )
-        self.assertEqual("Invalid output format: invalid", str(context.exception))
-
-    def test_query_changes_invalid_changes_output_expect_exception(self):
-        # Test & Assertion
-        with self.assertRaises(ValueError) as context:
-            self.worker_instance.query_changes(
-                sql_query=self.VALID_STAR_QUERY, changes_output="invalid"
-            )
-        self.assertEqual("Invalid changes output: invalid", str(context.exception))
-
     def test_query_changes_sql_with_update_expect_exception(self):
         # Test & Assertion
         with self.assertRaises(ValueError) as context:
@@ -47,20 +31,12 @@ class TestQueryChangesWorker(TestEimerDBInstanceBase):
 
     @parameterized.expand(
         [
-            (VALID_STAR_QUERY, True, "pandas", "all", 2),
-            (VALID_SELECT_QUERY, False, "pandas", "all", 2),
-            (VALID_STAR_QUERY, False, "pandas", "recent", 1),
-            (VALID_SELECT_QUERY, True, "pandas", "all", 2),
-            (VALID_STAR_QUERY, False, "arrow", "all", 2),
-            (VALID_STAR_QUERY, False, "arrow", "recent", 1),
+            (VALID_STAR_QUERY, 1),
         ]
     )
     def test_query_changes_pandas_all(
         self,
         sql_query: str,
-        unedited: bool,
-        output_format: str,
-        changes_output: str,
         expected_rows: int,
     ) -> None:
         # Mock the file system
@@ -109,10 +85,7 @@ class TestQueryChangesWorker(TestEimerDBInstanceBase):
             return_value=mock_duckdb_query_result,
         ):
             result: Union[pd.DataFrame, pa.Table] = self.worker_instance.query_changes(
-                sql_query=sql_query,
-                unedited=unedited,
-                output_format=output_format,
-                changes_output=changes_output,
+                sql_query=sql_query
             )
 
         # Assertions

--- a/tests/test_query_worker.py
+++ b/tests/test_query_worker.py
@@ -1,0 +1,178 @@
+from unittest.mock import ANY
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pandas as pd
+
+from eimerdb.instance_query_worker import QueryWorker
+from tests.test_instance_base import TestEimerDBInstanceBase
+
+
+class TestQueryWorker(TestEimerDBInstanceBase):
+
+    worker_instance: QueryWorker
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.worker_instance = QueryWorker(self.instance)
+
+    #
+    # query_select
+    #
+
+    @patch("eimerdb.instance.FileClient.get_gcs_file_system")
+    @patch("eimerdb.instance_query_worker.get_partitioned_files")
+    @patch("eimerdb.instance_query_worker.pq.read_table")
+    def test_query_select_success(
+        self,
+        mock_pq_read_table: Mock,
+        mock_get_partitioned_files: Mock,
+        mock_gcs_filesystem: Mock,
+    ) -> None:
+        # Mock input parameters
+        parsed_query = {"table_name": ["table1"]}
+        sql_query = "SELECT * FROM table1"
+        fs_mock = mock_gcs_filesystem.return_value
+        partition_select = None
+        unedited = False
+        output_format = "pandas"
+
+        # Mock return values
+        mock_pq_read_table.return_value = pd.DataFrame({"row_id": [1, 2, 3]})
+
+        # Call the method
+        result = self.worker_instance.query_select(
+            fs=fs_mock,
+            parsed_query=parsed_query,
+            sql_query=sql_query,
+            partition_select=partition_select,
+            unedited=unedited,
+            output_format=output_format,
+        )
+
+        assert result.equals(pd.DataFrame({"row_id": [1, 2, 3]}))
+
+        mock_get_partitioned_files.assert_called_once_with(
+            table_name="table1",
+            instance_name="test_eimerdb",
+            table_config=self.instance.tables["table1"],
+            suffix="_raw",
+            fs=fs_mock,
+            partition_select=partition_select,
+            unedited=unedited,
+        )
+        mock_pq_read_table.assert_called_once()
+
+    #
+    # query_update
+    #
+
+    def test_query_update_non_editable_table_expect_exception(self) -> None:
+        parsed_query = {
+            "operation": "UPDATE",
+            "set_clause": "field1=1",
+            "table_name": "table2",
+            "where_clause": "row_id='1'",
+        }
+
+        # Test & Assertion
+        with self.assertRaises(ValueError) as context:
+            self.worker_instance.query_update(
+                MagicMock(), parsed_query, "UPDATE table2 SET field1='1' WHERE row_id=1"
+            )
+        self.assertEqual(
+            "The table table2 is not editable!",
+            str(context.exception),
+        )
+
+    @patch("eimerdb.instance_query_worker.QueryWorker.query_select")
+    @patch("eimerdb.instance_query_worker.pq.write_to_dataset")
+    @patch("eimerdb.instance_query_worker.uuid4")
+    def test_query_update_success(
+        self, mock_uuid4: Mock, mock_write_to_dataset: Mock, mock_query_method: Mock
+    ) -> None:
+        # Setup mocks
+        mock_uuid4.return_value = "mocked_uuid"
+
+        mock_query_method.return_value = pd.DataFrame(
+            {"field1": [1, 2, 3], "row_id": ["1", "2", "3"]}
+        )
+
+        parsed_query = {
+            "operation": "UPDATE",
+            "set_clause": "field1=1",
+            "table_name": "table1",
+            "where_clause": "row_id='1'",
+        }
+
+        # Call the method
+        result = self.worker_instance.query_update(
+            MagicMock(), parsed_query, "UPDATE table1 SET field1=4 WHERE row_id='1'"
+        )
+
+        # Assertions
+        self.assertEqual("1 rows updated by user", result)
+
+        mock_write_to_dataset.assert_called_with(
+            table=ANY,
+            root_path="gs://test_bucket/path/to/eimer/table1_changes",
+            partition_cols=None,
+            basename_template="commit_mocked_uuid_{i}.parquet",
+            schema=self.instance.get_arrow_schema("table1", True),
+            filesystem=ANY,
+        )
+
+    #
+    # START _query_delete
+    #
+
+    def test_query_delete_non_editable_table_expect_exception(self) -> None:
+        parsed_query = {
+            "operation": "DELETE",
+            "table_name": "table2",
+            "where_clause": "row_id='1'",
+        }
+
+        # Test & Assertion
+        with self.assertRaises(ValueError) as context:
+            self.worker_instance.query_delete(fs=MagicMock(), parsed_query=parsed_query)
+        self.assertEqual(
+            "The table table2 is not editable!",
+            str(context.exception),
+        )
+
+    @patch("eimerdb.instance_query_worker.QueryWorker.query_select")
+    @patch("eimerdb.instance_query_worker.pq.write_to_dataset")
+    @patch("eimerdb.instance_query_worker.uuid4")
+    def test_query_delete_success(
+        self, mock_uuid4: Mock, mock_write_to_dataset: Mock, mock_query_method: Mock
+    ) -> None:
+        # Setup mocks
+        mock_uuid4.return_value = "mocked_uuid"
+
+        mock_query_method.return_value = pd.DataFrame(
+            {"field1": [1, 2, 3], "row_id": ["1", "2", "3"]}
+        )
+
+        parsed_query = {
+            "operation": "DELETE",
+            "table_name": "table1",
+            "where_clause": "row_id='1'",
+        }
+
+        # Call the method
+        result = self.worker_instance.query_delete(
+            fs=MagicMock(), parsed_query=parsed_query
+        )
+
+        # Assertions
+        self.assertEqual("1 rows deleted by user", result)
+
+        mock_write_to_dataset.assert_called_with(
+            table=ANY,
+            root_path="gs://test_bucket/path/to/eimer/table1_changes",
+            partition_cols=None,
+            basename_template="commit_mocked_uuid_{i}.parquet",
+            filesystem=ANY,
+        )


### PR DESCRIPTION
…r.py and instance_query_worker.py. EimerDBInstance now inherits AbstractDbInstance. docstring should be removed from instance.py, but docstring-inheritance doesn't support Python 3.13 yet.