### PR TITLE
added a "/" in _write_to_table_and_delete_blobs

### DIFF
--- a/src/eimerdb/instance.py
+++ b/src/eimerdb/instance.py
@@ -282,7 +282,7 @@ class EimerDBInstance(AbstractDbInstance):
         bucket = client.bucket(self._bucket_name)
 
         partitions = self._tables[table_name][PARTITION_COLUMNS_KEY]
-        blobs_to_delete = list(bucket.list_blobs(prefix=source_folder))
+        blobs_to_delete = list(bucket.list_blobs(prefix=source_folder + "/"))
 
         # noinspection PyTypeChecker
         pq.write_to_dataset(


### PR DESCRIPTION
The lack of a "/" in the source_folder included the _raw files un the bobs_to_delete when combining the inserts with raw=False. Added it to fix the problem